### PR TITLE
Raise for vtk <9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - python-version: '3.7'
-            vtk-version: '8.1.2'
+            vtk-version: '9.0.3' # v8.x not supported
           - python-version: '3.8'
             vtk-version: '9.0.3'
           - python-version: '3.9'

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -114,9 +114,8 @@ class VerifyImageCache:
         if self.skip:
             return
 
-        # Image cache is only valid for VTK9+
         if not VTK9:
-            return
+            raise RuntimeError("Image cache is only valid for VTK9+")
 
         if self.ignore_image_cache:
             return


### PR DESCRIPTION
vtk v8.x is not supported for image regressions.  At least this is how the code works now.  Returning `None` was a workaround in the `pyvista` package instead of skipping the tests.  Now that this package is decoupled, we should raise instead so that users know it isn't supported, otherwise confusion like https://github.com/pyvista/pytest-pyvista/pull/19#issuecomment-1365009955 occurs.