### PR TITLE
Option for skipping on vtk8

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - python-version: '3.7'
-            vtk-version: '9.0.3' # v8.x not supported
+            vtk-version: '8.1.2'
           - python-version: '3.8'
             vtk-version: '9.0.3'
           - python-version: '3.9'

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -76,6 +76,7 @@ class VerifyImageCache:
     ignore_image_cache = False
     fail_extra_image_cache = False
     skip_image_cache_vtk8 = False
+
     def __init__(
         self,
         test_name,

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -6,7 +6,7 @@ import pyvista as pv
 
 pv.OFF_SCREEN = True
 skip_vtk8 = pytest.mark.skipif(pv.vtk_version_info < (9,), reason="vtk8 not supported")
-
+skip_vtk9 = pytest.mark.skipif(pv.vtk_version_info >= (9,), reason="vtk8 only test")
 
 @skip_vtk8
 def test_arguments(testdir):
@@ -189,7 +189,7 @@ def test_high_variance_test(testdir):
     result = testdir.runpytest("--fail_extra_image_cache", "test_file2.py")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
-
+@skip_vtk9
 def test_skip_vtk8_commandline(testdir):
     """Test skip vtk8 via CLI option."""
     make_cached_images(testdir.tmpdir)


### PR DESCRIPTION
`pyvista` tests include plotting with vtk version 8 but do not support image caching.  However, it is still useful to test that the tests run on these versions without error.  This PR adds the option to raise an error for vtk8 (default) or skip image cache testing.

This would fix vtk version related failures for https://github.com/pyvista/pyvista/pull/3748