### PR TITLE
Remove PyVista from dependencies

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install pytest-pyvista with test dependencies
-        run: pip install .[docs]
+        run: pip install .[docs] 'pyvista>=0.37'
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
         with:
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install pytest-pyvista with test dependencies
         run: |
-          pip install .[tests]
+          pip install .[tests] 'pyvista>=0.37'
 
       - name: Set up vtk
         if: ${{ matrix.vtk-version != 'latest' }}
@@ -108,7 +108,7 @@ jobs:
       github.event_name == 'push' &&
       contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-  
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
 ]
-dependencies=["pytest>=3.5.0", "pyvista>=0.37"]
+dependencies=["pytest>=3.5.0"]
 python_requires=">=3.7"
 
 [project.urls]
@@ -34,7 +34,6 @@ tests = [
     "coverage==7.0.5",
     "pytest>=3.5.0",
     "pytest-cov==4.0.0",
-    "pyvista",
     "numpy<1.24",
 ]
 docs = [


### PR DESCRIPTION
Having PyVista as a hard dependency provides a headache for installing targeted versions of both PyVista and VTK.

PyVista has `vtk` listed as a requirement, and I don't think we want to remove that. We are beginning to use new `vtk_osmesa` wheels for CI and we need to be able to have `pytest-pyvista` in `requirements.txt` without a `--no-deps` option. Problem is, this pulls/checks pyvista and thus pulls `vtk`. This provides an issue if using the `vtk_osmesa` (or other build variant) wheel and will also mess with the pyvista install if the version isn't right.

IMO, if you're using `pytest-pyvista`, it's obvious you'll need `pyvista` installed and thus removing it as a dependency here shouldn't be too confusing.

After all, this module is not meant to be directly interfaced with by users but only integrated into existing testing workflows with PyVista.