### PR TITLE
Fix CI; Remove python 3.7; remove flake8-isort

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,8 +59,6 @@ jobs:
 
       matrix:
         include:
-          - python-version: '3.7'
-            vtk-version: '9.0.3'
           - python-version: '3.8'
             vtk-version: '9.0.3'
           - python-version: '3.9'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
   - id: flake8
     additional_dependencies: [
       "flake8-black==0.3.3",
-      "flake8-isort==4.2.0",
       "flake8-quotes==3.3.1",
     ]
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ fail.
 
 Requirements
 ------------
-You must have a Python version greater than 3.7, as well as PyVista installed
+You must have a Python version >= 3.8, as well as PyVista installed
 in your environment.
 
 pyvista version >=0.37.0 and vtk version >=9.0.0 required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers=[
     "Framework :: Pytest",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Testing",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -22,7 +21,7 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
 ]
 dependencies=["pytest>=3.5.0"]
-python_requires=">=3.7"
+python_requires=">=3.8"
 
 [project.urls]
 Home = "https://github.com/pyvista/pytest-pyvista"


### PR DESCRIPTION
CI is starting to fail due to conflicts with python 3.7. PyVista no longer supports this version, so we should drop here too.