### PR TITLE
Reset cache only if error

### DIFF
--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -119,7 +119,7 @@ class VerifyImageCache:
         warning_value=200.0,
         var_error_value=1000.0,
         var_warning_value=1000.0,
-        generated_image_dir=None
+        generated_image_dir=None,
     ):
         self.test_name = test_name
 
@@ -191,7 +191,7 @@ class VerifyImageCache:
         # "test_" to get the name for the image.
         image_name = test_name[5:] + ".png"
         image_filename = os.path.join(self.cache_dir, image_name)
-        
+
         if (
             not os.path.isfile(image_filename)
             and self.fail_extra_image_cache
@@ -222,7 +222,8 @@ class VerifyImageCache:
                 warnings.warn(
                     f"{test_name} Exceeded image regression error of "
                     f"{allowed_error} with an image error equal to: {error}"
-                    f"\nThis image will be reset in the cache.")
+                    f"\nThis image will be reset in the cache."
+                )
                 plotter.screenshot(image_filename)
             else:
                 # Make sure this doesn't get called again if this plotter doesn't close properly

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -45,6 +45,11 @@ def pytest_addoption(parser):
         default="image_cache_dir",
         help="Path to the image cache folder.",
     )
+    group.addoption(
+        "--reset_only_failed",
+        action="store_true",
+        help="Reset only the failed images in the PyVista cache.",
+    )
 
 
 class VerifyImageCache:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -119,7 +119,7 @@ class VerifyImageCache:
         var_error_value=1000.0,
         var_warning_value=1000.0,
         generated_image_dir=None,
-        reset_only_failed=False
+        reset_only_failed=False,
     ):
         self.test_name = test_name
 
@@ -202,13 +202,10 @@ class VerifyImageCache:
             raise RuntimeError(f"{image_filename} does not exist in image cache")
 
         if (
-            (
-                self.add_missing_images
-                and not os.path.isfile(image_filename)
-                or self.reset_image_cache
-            )
-            and not self.reset_only_failed
-        ):
+            self.add_missing_images
+            and not os.path.isfile(image_filename)
+            or self.reset_image_cache
+        ) and not self.reset_only_failed:
             plotter.screenshot(image_filename)
 
         if self.generated_image_dir is not None:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -114,6 +114,7 @@ class VerifyImageCache:
         var_error_value=1000.0,
         var_warning_value=1000.0,
         generated_image_dir=None,
+        reset_only_failed=False
     ):
         self.test_name = test_name
 
@@ -129,6 +130,7 @@ class VerifyImageCache:
         self.warning_value = warning_value
         self.var_error_value = var_error_value
         self.var_warning_value = var_warning_value
+        self.reset_only_failed = reset_only_failed
 
         self.generated_image_dir = generated_image_dir
         if self.generated_image_dir is not None and not os.path.isdir(
@@ -183,7 +185,8 @@ class VerifyImageCache:
 
         # cached image name. We remove the first 5 characters of the function name
         # "test_" to get the name for the image.
-        image_filename = os.path.join(self.cache_dir, test_name[5:] + ".png")
+        image_name = test_name[5:] + ".png"
+        image_filename = os.path.join(self.cache_dir, image_name)
         if (
             not os.path.isfile(image_filename)
             and self.fail_extra_image_cache
@@ -194,9 +197,12 @@ class VerifyImageCache:
             raise RuntimeError(f"{image_filename} does not exist in image cache")
 
         if (
-            self.add_missing_images
-            and not os.path.isfile(image_filename)
-            or self.reset_image_cache
+            (
+                self.add_missing_images
+                and not os.path.isfile(image_filename)
+                or self.reset_image_cache
+            )
+            and not self.reset_only_failed
         ):
             plotter.screenshot(image_filename)
 
@@ -205,15 +211,19 @@ class VerifyImageCache:
                 self.generated_image_dir, test_name[5:] + ".png"
             )
             plotter.screenshot(gen_image_filename)
+
         error = pyvista.compare_images(image_filename, plotter)
 
         if error > allowed_error:
-            # Make sure this doesn't get called again if this plotter doesn't close properly
-            plotter._before_close_callback = None
-            raise RuntimeError(
-                f"{test_name} Exceeded image regression error of "
-                f"{allowed_error} with an image error equal to: {error}"
-            )
+            if self.reset_only_failed:
+                plotter.screenshot(image_filename)
+            else:
+                # Make sure this doesn't get called again if this plotter doesn't close properly
+                plotter._before_close_callback = None
+                raise RuntimeError(
+                    f"{test_name} Exceeded image regression error of "
+                    f"{allowed_error} with an image error equal to: {error}"
+                )
         if error > allowed_warning:
             warnings.warn(
                 f"{test_name} Exceeded image regression warning of "

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -217,7 +217,6 @@ class VerifyImageCache:
         error = pyvista.compare_images(image_filename, plotter)
 
         if error > allowed_error:
-            print("self.reset_only_failed", self.reset_only_failed)
             if self.reset_only_failed:
                 warnings.warn(
                     f"{test_name} Exceeded image regression error of "

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -282,6 +282,7 @@ def test_cleanup(testdir):
     result = testdir.runpytest("--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
+
 def test_reset_only_failed(testdir):
     """Test usage of the `reset_only_failed` flag."""
     make_cached_images(testdir.tmpdir)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -285,7 +285,10 @@ def test_cleanup(testdir):
 
 def test_reset_only_failed(testdir):
     """Test usage of the `reset_only_failed` flag."""
-    make_cached_images(testdir.tmpdir)
+    filename = make_cached_images(testdir.tmpdir)
+    filename_original = make_cached_images(testdir.tmpdir, name="original.png")
+    assert filecmp.cmp(filename, filename_original, shallow=False)
+
     testdir.makepyfile(
         """
         import pyvista as pv
@@ -301,3 +304,5 @@ def test_reset_only_failed(testdir):
     result = testdir.runpytest("--reset_only_failed")
     result.stdout.fnmatch_lines("*[Pp]assed*")
     result.stdout.fnmatch_lines("*This image will be reset in the cache.")
+    # file was overwritten
+    assert not filecmp.cmp(filename, filename_original, shallow=False)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -281,3 +281,22 @@ def test_cleanup(testdir):
 
     result = testdir.runpytest("--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
+
+def test_reset_only_failed(testdir):
+    """Test usage of the `reset_only_failed` flag."""
+    make_cached_images(testdir.tmpdir)
+    testdir.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+        def test_imcache(verify_image_cache):
+            sphere = pv.Box()
+            plotter = pv.Plotter()
+            plotter.add_mesh(sphere, color="blue")
+            plotter.show()
+        """
+    )
+
+    result = testdir.runpytest("--reset_only_failed")
+    result.stdout.fnmatch_lines("*[Pp]assed*")
+    result.stdout.fnmatch_lines("*This image will be reset in the cache.")


### PR DESCRIPTION
As the title.

It resets the cache if the image comparison fails.
It does not raise an error.

Working on the tests...

Close #83 