### PR TITLE
NEP29 Compliance

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,8 +59,6 @@ jobs:
 
       matrix:
         include:
-          - python-version: '3.8'
-            vtk-version: '9.0.3'
           - python-version: '3.9'
             vtk-version: '9.1'
           - python-version: '3.10'
@@ -84,10 +82,6 @@ jobs:
       - name: Set up vtk
         if: ${{ matrix.vtk-version != 'latest' }}
         run: pip install vtk==${{ matrix.vtk-version }}
-
-      - name: Limit NumPy for VTK 9.0.3
-        if: ${{ matrix.vtk-version == '9.0.3' }}
-        run: pip install 'numpy<1.24'
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,9 @@ repos:
   rev: 0.26.3
   hooks:
     - id: check-github-workflows
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: "v0.14"
+  hooks:
+    - id: validate-pyproject
+

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ fail.
 
 Requirements
 ------------
-You must have a Python version >= 3.8, as well as PyVista installed
+You must have a Python version >= 3.9, as well as PyVista installed
 in your environment.
 
 pyvista version >=0.37.0 and vtk version >=9.0.0 required.

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ pytest-pyvista
     :target: https://github.com/pyvista/pytest-pyvista/actions/workflows/ci_cd.yml
     :alt: GitHub Actions: Unit Testing and Deployment
 
+.. image:: https://raster.shields.io/badge/follows-NEP29-orange.png
+    :target: https://numpy.org/neps/nep-0029-deprecation_policy.html
+    :alt: NEP29 Compliance
+
 Plugin to test PyVista plot outputs.
 
 ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ tests = [
     "coverage==7.3.1",
     "pytest>=3.5.0",
     "pytest-cov==4.1.0",
-    "numpy>=1.21,<1.26",
+    "numpy>1.21,<1.26",
 ]
 docs = [
     "pydata-sphinx-theme==0.13.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
 ]
 dependencies=["pytest>=3.5.0"]
-python_requires=">=3.8"
+requires-python=">=3.9"
 
 [project.urls]
 Home = "https://github.com/pyvista/pytest-pyvista"
@@ -33,7 +33,7 @@ tests = [
     "coverage==7.3.1",
     "pytest>=3.5.0",
     "pytest-cov==4.1.0",
-    "numpy<1.26",
+    "numpy>=1.21,<1.26",
 ]
 docs = [
     "pydata-sphinx-theme==0.13.3",


### PR DESCRIPTION
This PR adopts the [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) for minimum supported versions of `python` and `numpy`.

When working on #84 I noticed that the PyPI versions were wrong for `pytest-pyvista`. Turns out, incorrect syntax (probably migrated from `setup.py` or `setup.cfg`) was used to specify the required `python` version for the package; minor fix sorted this.

Went the extra mile and also configured the  [validate-pyproject](https://github.com/abravalheri/validate-pyproject) pre-commit hook to automate continued confidence in the `pyproject.toml`.