### PR TITLE
Add generated_image_dir ini configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,11 +104,12 @@ These are the flags you can use when calling ``pytest`` in the command line:
 * When using ``--fail_extra_image_cache`` if there is an extra image in the
   cache, it will report as an error.
   
-* ``--generated_image_dir <DIR>`` dumps all generated test images into <DIR>.
+* ``--generated_image_dir <DIR>`` dumps all generated test images into the provided
+  directory.  This will override any configuration, see below.
 
 * ``--add_missing_images`` adds any missing images from the test run to the cache.
 
-* ``--image_cache_dir <DIR>`` sets the image cache dir.  This will override any
+* ``--image_cache_dir <DIR>`` sets the image cache directory.  This will override any
   configuration, see below.
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
@@ -138,12 +139,20 @@ If using ``pyproject.toml`` or any other
 `pytest configuration <https://docs.pytest.org/en/latest/reference/customize.html>`_
 section, consider configuring your test directory location to
 avoid passing command line arguments when calling ``pytest``, for example in
-``pyproject.toml``
+``pyproject.toml``:
 
 .. code::
 
    [tool.pytest.ini_options]
    image_cache_dir = "tests/plotting/image_cache"
+
+Additionally, to configure the directory that will contain the generated test images:
+
+.. code::
+
+   [tool.pytest.ini_options]
+   generated_image_dir = "generated_images"
+
 
 Contributing
 ------------

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -42,6 +42,11 @@ def pytest_addoption(parser):
         action="store",
         help="Path to dump test images from the current run.",
     )
+    parser.addini(
+        "generated_image_dir",
+        default="generated_image_dir",
+        help="Path to dump test images from the current run.",
+    )
     group.addoption(
         "--add_missing_images",
         action="store_true",
@@ -271,6 +276,8 @@ def verify_image_cache(request, pytestconfig):
         cache_dir = pytestconfig.getini("image_cache_dir")
 
     gen_dir = pytestconfig.getoption("generated_image_dir")
+    if gen_dir is None:
+        gen_dir = pytestconfig.getini("generated_image_dir")
 
     verify_image_cache = VerifyImageCache(
         request.node.name, cache_dir, generated_image_dir=gen_dir

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -210,6 +210,32 @@ def test_generated_image_dir_commandline(testdir):
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
+def test_generated_image_dir_ini(testdir):
+    """Test setting generated_image_dir via config."""
+    make_cached_images(testdir.tmpdir)
+    testdir.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+        def test_imcache(verify_image_cache):
+            sphere = pv.Sphere()
+            plotter = pv.Plotter()
+            plotter.add_mesh(sphere, color="red")
+            plotter.show()
+        """
+    )
+    testdir.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        generated_image_dir = "gen_dir"
+        """
+    )
+    result = testdir.runpytest("--fail_extra_image_cache")
+    assert os.path.isdir(os.path.join(testdir.tmpdir, "gen_dir"))
+    assert os.path.isfile(os.path.join(testdir.tmpdir, "gen_dir", "imcache.png"))
+    result.stdout.fnmatch_lines("*[Pp]assed*")
+
+
 def test_add_missing_images_commandline(testdir):
     """Test setting add_missing_images via CLI option."""
     testdir.makepyfile(


### PR DESCRIPTION
This pull-request adds the convenience of specifying the `generated_image_dir` as a `pytest` INI configuration option, complimenting its associated CLI option.

This is akin to the support provided for the `image_cache_dir` option.