### PR TITLE
Add Python3.12 support at the latest `vtk` version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -67,6 +67,8 @@ jobs:
             vtk-version: '9.2.2'
           - python-version: '3.11'
             vtk-version: 'latest'
+          - python-version: '3.12'
+            vtk-version: 'latest'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Add Python3.12 support at the latest `vtk` version.