### PR TITLE
Drop Python 3.8 support which is EOL in 07 Oct 2024

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,8 +59,6 @@ jobs:
 
       matrix:
         include:
-          - python-version: '3.8'
-            vtk-version: '9.0.3'
           - python-version: '3.9'
             vtk-version: '9.1'
           - python-version: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ fail.
 
 Requirements
 ------------
-You must have a Python version >= 3.8, as well as PyVista installed
+You must have a Python version >= 3.9, as well as PyVista installed
 in your environment.
 
 pyvista version >=0.37.0 and vtk version >=9.0.0 required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers=[
     "Framework :: Pytest",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Testing",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -21,7 +20,7 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
 ]
 dependencies=["pytest>=3.5.0"]
-python_requires=">=3.8"
+python_requires=">=3.9"
 
 [project.urls]
 Home = "https://github.com/pyvista/pytest-pyvista"


### PR DESCRIPTION
ref https://github.com/pyvista/pyvista/pull/6701