### PR TITLE
Modernize testing versions and installation in CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -67,6 +67,8 @@ jobs:
             vtk-version: "latest"
           - python-version: "3.12"
             vtk-version: "latest"
+          - python-version: "3.13"
+            vtk-version: "latest"
     steps:
       - uses: actions/checkout@v4
 
@@ -153,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - run: git clone --depth=1 https://github.com/pyvista/pyvista.git --branch main --single-branch
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   doc:
     name: Build Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -148,7 +148,7 @@ jobs:
 
   downstream:
     name: Downstream tests
-    runs-on: ubuntu-20.04 # matching pyvista
+    runs-on: ubuntu-22.04 # matching pyvista
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -159,14 +159,13 @@ jobs:
 
       - run: git clone --depth=1 https://github.com/pyvista/pyvista.git --branch main --single-branch
 
-      - name: Install pyvista
-        run: pip install -ve .
-        working-directory: pyvista
-      - name: Install pyvista test requirements
-        run: pip install -v pyvista[test]
+      - name: upgrade pip
+        run: pip install --upgrade pip
+      - name: Install pyvista with testing requirements
+        run: pip install -ve . --group test
         working-directory: pyvista
       - name: Install pytest-pyvista
-        run: pip install -ve .
+        run: pip install -ve .  --upgrade
       - name: Software Report
         run: |
           xvfb-run python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]


### PR DESCRIPTION
ubuntu-20.04 is unsupported.

https://github.com/actions/runner-images/issues/11101

Further fixes are adding python 3.13 testing support and updating to use --group installation requirements from pyvista.