### PR TITLE
Add `disallow_unused_cache` option

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest -v --disallow_unused_cache --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py --allow_unused_cache
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir --fail_unused_cache tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir --fail_unused_cache tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest -v --allow_unused_cache --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest -v --disallow_unused_cache --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -103,7 +103,7 @@ jobs:
           pip list
 
       - name: Unit Testing
-        run: xvfb-run coverage run -m --source=pytest_pyvista --module pytest --verbose .
+        run: xvfb-run coverage run --branch --source=pytest_pyvista -m pytest --verbose .
       - uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.9'
         name: "Upload coverage to CodeCov"

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
-* ``--fail_unused_cache`` report test failure if there are any images in the cache
+* ``--allow_unused_cache`` report test failure if there are any images in the cache
   which are not compared to any generated images.
 
 Test specific flags

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
+* ``--fail_unused_cache`` report test failure if there are any images in the cache
+  which are not compared to any generated images.
+
 Test specific flags
 -------------------
 These are attributes of `verify_image_cache`. You can set them as ``True`` if needed

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
   cache (e.g. if using ``--add_missing_images``). Otherwise, an error is raised by
   default.
 
-* ``--allow_unused_cache`` report test failure if there are any images in the cache
+* ``--disallow_unused_cache`` report test failure if there are any images in the cache
   which are not compared to any generated images.
 
 Test specific flags

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -285,11 +285,14 @@ RESULTS = {}
 
 
 def _store_result(*, test_name: str, outcome: Outcome, cached_filename: str, generated_filename: str | None = None) -> None:
-    result = _ResultTuple(
-        outcome=outcome,
-        cached_filename=str(Path(cached_filename).name),
-        generated_filename=str(Path(generated_filename).name) if generated_filename else None,
-    )
+    try:
+        result = _ResultTuple(
+            outcome=outcome,
+            cached_filename=str(Path(cached_filename).name),
+            generated_filename=str(Path(generated_filename).name) if generated_filename else None,
+        )
+    except Exception:  # noqa: BLE001
+        pytest.fail(f"test_name: {test_name}, outcome: {outcome}, cached: {cached_filename}, generated: {generated_filename}")
     RESULTS[test_name] = result
 
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -80,7 +80,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
         help="Reset only the failed images in the PyVista cache.",
     )
     group.addoption(
-        "--fail_unused_cache",
+        "--allow_unused_cache",
         action="store_true",
         help="Report test failure if there are any images in the cache which are not compared to any generated images.",
     )
@@ -317,12 +317,12 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
     config = session.config
 
     image_cache_dir = config.getoption("image_cache_dir")
-    fail_unused_cache = config.getoption("fail_unused_cache")
+    allow_unused_cache = config.getoption("allow_unused_cache")
 
     if image_cache_dir is None:
         image_cache_dir = config.getini("image_cache_dir")
 
-    if image_cache_dir and fail_unused_cache:
+    if image_cache_dir and not allow_unused_cache:
         cache_path = Path(image_cache_dir)
         cached_files = {f.name for f in cache_path.glob("*.png")}
         tested_files = {result.cached_filename for result in RESULTS.values()}

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -266,24 +266,6 @@ def _store_result(*, test_name: str, outcome: str, cached_filename: str, generat
     RESULTS[test_name] = result
 
 
-@pytest.hookimpl
-def pytest_collection_modifyitems(session, config, items) -> None:  # noqa: ANN001, ARG001
-    """Record skipped tests during collection."""
-    for item in items:
-        # Check if test is marked to be skipped at collection time
-        if isinstance(item, pytest.Function):
-            skip_marker = item.get_closest_marker("skip")
-            skipif_marker = item.get_closest_marker("skipif")
-            if skip_marker is not None or (skipif_marker is not None and skipif_marker.args and skipif_marker.args[0]):
-                test_name = item.name
-                _store_result(
-                    test_name=test_name,
-                    outcome="skipped",
-                    cached_filename=_image_name_from_test_name(test_name),
-                    generated_filename=None,
-                )
-
-
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
     """Store test results for skipped tests."""

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -333,7 +333,7 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
             test_name = _test_name_from_image_name(image_name)
             result = RESULTS.get(test_name)
             if result and result.outcome == Outcome.SKIPPED:
-                unused.remove(image_name)
+                unused_skipped.remove(image_name)
 
         if unused_skipped:
             msg = (

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -95,7 +95,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
         help="Reset only the failed images in the PyVista cache.",
     )
     group.addoption(
-        "--allow_unused_cache",
+        "--disallow_unused_cache",
         action="store_true",
         help="Report test failure if there are any images in the cache which are not compared to any generated images.",
     )
@@ -380,12 +380,12 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
     config = session.config
 
     image_cache_dir = config.getoption("image_cache_dir")
-    allow_unused_cache = config.getoption("allow_unused_cache")
+    disallow_unused_cache = config.getoption("disallow_unused_cache")
 
     if image_cache_dir is None:
         image_cache_dir = config.getini("image_cache_dir")
 
-    if image_cache_dir and not allow_unused_cache:
+    if image_cache_dir and disallow_unused_cache:
         cache_path = Path(image_cache_dir)
         cached_files = {f.name for f in cache_path.glob("*.png")}
         tested_files = {result.cached_filename for result in RESULTS.values()}

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -285,14 +285,11 @@ RESULTS = {}
 
 
 def _store_result(*, test_name: str, outcome: Outcome, cached_filename: str, generated_filename: str | None = None) -> None:
-    try:
-        result = _ResultTuple(
-            outcome=outcome,
-            cached_filename=str(Path(cached_filename).name),
-            generated_filename=str(Path(generated_filename).name) if generated_filename else None,
-        )
-    except Exception:  # noqa: BLE001
-        pytest.fail(f"test_name: {test_name}, outcome: {outcome}, cached: {cached_filename}, generated: {generated_filename}")
+    result = _ResultTuple(
+        outcome=outcome,
+        cached_filename=str(Path(cached_filename).name),
+        generated_filename=str(Path(generated_filename).name) if generated_filename else None,
+    )
     RESULTS[test_name] = result
 
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -267,6 +267,24 @@ def _store_result(*, test_name: str, outcome: str, cached_filename: str, generat
     RESULTS[test_name] = result
 
 
+@pytest.hookimpl
+def pytest_collection_modifyitems(session, config, items) -> None:  # noqa: ANN001, ARG001
+    """Record skipped tests during collection."""
+    for item in items:
+        # Check if test is marked to be skipped at collection time
+        if isinstance(item, pytest.Function):
+            skip_marker = item.get_closest_marker("skip")
+            skipif_marker = item.get_closest_marker("skipif")
+            if skip_marker is not None or (skipif_marker is not None and skipif_marker.args and skipif_marker.args[0]):
+                test_name = item.name
+                _store_result(
+                    test_name=test_name,
+                    outcome="skipped",
+                    cached_filename=_image_name_from_test_name(test_name),
+                    generated_filename=None,
+                )
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
     """Store test results for skipped tests."""

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -311,7 +311,11 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
         tested_files = {result.cached_filename for result in RESULTS.values()}
         unused = cached_files - tested_files
         if unused:
-            msg = f"Unused cached image files detected. The following images were not used by any of the tests:\n{sorted(unused)}"
+            msg = (
+                f"Unused cached image files detected ({len(unused)}).\n"
+                f"The following cached images were not generated or skipped by any of the tests:\n"
+                f"{sorted(unused)}"
+            )
             raise RuntimeError(msg)
 
     RESULTS.clear()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -82,7 +82,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
     group.addoption(
         "--fail_unused_cache",
         action="store_true",
-        help="Enables failure if there are any images in the cache which were not compared during the test.",
+        help="Report test failure if there are any images in the cache which are not compared to any generated images.",
     )
 
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -12,7 +12,7 @@ import warnings
 import pytest
 import pyvista
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
 
 
@@ -217,11 +217,10 @@ class VerifyImageCache:
         if ((self.add_missing_images and not os.path.isfile(image_filename)) or self.reset_image_cache) and not self.reset_only_failed:  # noqa: PTH113
             plotter.screenshot(image_filename)
 
+        gen_image_filename = None
         if self.generated_image_dir is not None:
             gen_image_filename = os.path.join(self.generated_image_dir, test_name[5:] + ".png")  # noqa: PTH118
             plotter.screenshot(gen_image_filename)
-        else:
-            gen_image_filename = None
 
         error = pyvista.compare_images(image_filename, plotter)
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -6,6 +6,7 @@ from enum import Enum
 import os
 from pathlib import Path
 import platform
+import sys
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 import warnings
@@ -337,11 +338,15 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
 
         if unused_skipped:
             msg = (
-                f"Unused cached image files detected ({len(unused_skipped)}).\n"
-                f"The following cached images were not generated or skipped by any of the tests:\n"
-                f"{sorted(unused_skipped)}"
+                f"\npytest-pyvista: ERROR: Unused cached image file(s) detected ({len(unused_skipped)}).\n"
+                f"The following images were not generated or skipped by any of the tests:\n"
+                f"{sorted(unused_skipped)}\n"
             )
-            raise RuntimeError(msg)
+            # Print the message so it appears in the output
+            sys.stderr.write(msg)
+            sys.stderr.flush()
+
+            session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
     RESULTS.clear()
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -300,9 +300,6 @@ def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
     if outcome:
         rep = outcome.get_result()
 
-        # Attach the report to the item so fixtures/finalizers can inspect it
-        setattr(item, f"rep_{rep.when}", rep)
-
         # Log if test was skipped
         if rep.when in ["call", "setup"] and rep.skipped:
             test_name = item.name
@@ -377,15 +374,6 @@ def verify_image_cache(request, pytestconfig):  # noqa: ANN001, ANN201
 
     def reset() -> None:
         pyvista.global_theme.before_close_callback = None
-
-        # Retrieve test call report
-        rep_call = getattr(request.node, "rep_call", None)
-
-        if rep_call and rep_call.passed and verify_image_cache.n_calls == 0:
-            pytest.fail(
-                "Fixture `verify_image_cache` is used but no images were generated.\n"
-                "Did you forget to call `show` or `plot`, or set `verify_image_cache.skip = True`?."
-            )
 
     request.addfinalizer(reset)  # noqa: PT021
     return verify_image_cache

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -21,7 +21,7 @@ def test_arguments(testdir) -> None:
 
         """
     )
-    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--fail_extra_image_cache")
+    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--fail_extra_image_cache", "--fail_unused_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -381,9 +381,9 @@ class HasUnusedCache(Enum):  # noqa: D101
         return self.value
 
 
-RUNTIME_ERROR_LINES = [
-    "RuntimeError: Unused cached image files detected (1).",
-    "The following cached images were not generated or skipped by any of the tests:",
+TESTS_FAILED_ERROR_LINES = [
+    "pytest-pyvista: ERROR: Unused cached image file(s) detected (1).",
+    "The following images were not generated or skipped by any of the tests:",
 ]
 
 
@@ -398,9 +398,9 @@ RUNTIME_ERROR_LINES = [
         (PytestMark.NONE, SkipVerify.IGNORE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
         (PytestMark.NONE, SkipVerify.SKIP, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
         (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.FALSE),
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),  # noqa: E501
+        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
     ],
 )
 # fmt: on
@@ -484,4 +484,4 @@ def test_fail_unused_cache_name_mismatch(testdir) -> None:
     )
 
     result = testdir.runpytest("--fail_unused_cache")
-    result.stderr.fnmatch_lines([*RUNTIME_ERROR_LINES, f"[{image_name!r}]"])
+    result.stderr.fnmatch_lines([*TESTS_FAILED_ERROR_LINES, f"[{image_name!r}]"])

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -485,35 +485,3 @@ def test_fail_unused_cache_name_mismatch(testdir) -> None:
 
     result = testdir.runpytest("--fail_unused_cache")
     result.stderr.fnmatch_lines([*TESTS_FAILED_ERROR_LINES, f"[{image_name!r}]"])
-
-
-@pytest.mark.parametrize("call_show", [True, False])
-def test_verify_image_cache_has_no_effect(testdir, call_show) -> None:
-    """Test error is raised if fixture is used but no images are generated."""
-    if call_show:
-        make_cached_images(testdir.tmpdir)
-
-    testdir.makepyfile(
-        f"""
-        import pyvista as pv
-        pv.OFF_SCREEN = True
-        def test_imcache(verify_image_cache):
-            sphere = pv.Sphere()
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="red")
-            {'plotter.show()' if call_show else ''}
-        """
-    )
-
-    result = testdir.runpytest()
-    expected_code =pytest.ExitCode.OK if call_show else pytest.ExitCode.TESTS_FAILED
-    assert result.ret == expected_code
-    result.stdout.fnmatch_lines("*[Pp]assed*")
-    if not call_show:
-        result.stdout.fnmatch_lines(
-            [
-                "*ERROR at teardown of test_imcache*",
-                "*Failed: Fixture `verify_image_cache` is used but no images were generated.",
-                "*Did you forget to call `show` or `plot`, or set `verify_image_cache.skip = True`?."
-            ]
-        )

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -426,7 +426,6 @@ def test_fail_unused_cache(testdir, marker, skip_verify, color, stdout_lines, st
             plotter = pv.Plotter()
             plotter.add_mesh(sphere, color="{color}")
             plotter.show()
-            plotter.close()
         """
     )
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -353,17 +353,21 @@ RUNTIME_ERROR_MSG = "RuntimeError: Unused cached image files detected. The follo
 
 
 @pytest.mark.parametrize(
-    ("marker", "color", "stdout_lines", "stderr_lines", "exit_code", "unused_cache"),
+    ("marker", "skip_verify", "color", "stdout_lines", "stderr_lines", "exit_code", "unused_cache"),
     [
-        ("@pytest.mark.skip", "red", ["*skipped*"], [], pytest.ExitCode.OK, False),
-        ("", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
-        ("", "blue", ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, False),
-        ("@pytest.mark.skip", "red", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
-        ("", "red", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
-        ("", "blue", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
+        ("@pytest.mark.skip", "", "red", ["*skipped*"], [], pytest.ExitCode.OK, False),
+        ("", "", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
+        ("", "verify_image_cache.macos_skip_image_cache", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
+        ("", "verify_image_cache.windows_skip_image_cache", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
+        ("", "verify_image_cache.ignore_image_cache", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
+        ("", "verify_image_cache.skip", "red", ["*[Pp]assed*"], [], pytest.ExitCode.OK, False),
+        ("", "", "blue", ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, False),
+        ("@pytest.mark.skip", "", "red", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
+        ("", "", "red", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
+        ("", "", "blue", [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, True),
     ],
 )
-def test_fail_unused_cache(testdir, marker, color, stdout_lines, stderr_lines, exit_code, unused_cache) -> None:  # noqa: PLR0913
+def test_fail_unused_cache(testdir, marker, skip_verify, color, stdout_lines, stderr_lines, exit_code, unused_cache) -> None:  # noqa: PLR0913
     """Ensure unused cached images are detected correctly."""
     test_name = "foo"
     image_name = test_name + ".png"
@@ -380,6 +384,7 @@ def test_fail_unused_cache(testdir, marker, color, stdout_lines, stderr_lines, e
         pv.OFF_SCREEN = True
         {marker}
         def test_{test_name}(verify_image_cache):
+            {skip_verify}
             sphere = pv.Sphere()
             plotter = pv.Plotter()
             plotter.add_mesh(sphere, color="{color}")

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -381,7 +381,10 @@ class HasUnusedCache(Enum):  # noqa: D101
         return self.value
 
 
-RUNTIME_ERROR_MSG = "RuntimeError: Unused cached image files detected. The following images were not used by any of the tests:"
+RUNTIME_ERROR_LINES = [
+    "RuntimeError: Unused cached image files detected (1).",
+    "The following cached images were not generated or skipped by any of the tests:",
+]
 
 
 # fmt: off
@@ -395,9 +398,9 @@ RUNTIME_ERROR_MSG = "RuntimeError: Unused cached image files detected. The follo
         (PytestMark.NONE, SkipVerify.IGNORE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
         (PytestMark.NONE, SkipVerify.SKIP, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
         (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.FALSE),
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE), # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),# noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [RUNTIME_ERROR_MSG, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),# noqa: E501
+        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE), # noqa: E501
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),# noqa: E501
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [*RUNTIME_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.INTERNAL_ERROR, HasUnusedCache.TRUE),# noqa: E501
     ],
 )
 # fmt: on

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -21,7 +21,7 @@ def test_arguments(testdir) -> None:
 
         """
     )
-    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--allow_unused_cache")
+    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--disallow_unused_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -503,7 +503,7 @@ TESTS_FAILED_ERROR_LINES = [
         (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
     ],
 )  # fmt: skip
-def test_allow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, stderr_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
+def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, stderr_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
     """Ensure unused cached images are detected correctly."""
     test_name = "foo"
     image_name = test_name + ".png"
@@ -528,7 +528,7 @@ def test_allow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, s
         """
     )
 
-    result = testdir.runpytest()
+    result = testdir.runpytest("--disallow_unused_cache")
 
     assert result.ret == exit_code
     result.stderr.fnmatch_lines(stderr_lines)
@@ -536,8 +536,8 @@ def test_allow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, s
 
 
 @pytest.mark.parametrize("skip", [True,False])
-@pytest.mark.parametrize("args", ["--allow_unused_cache", []])
-def test_allow_unused_cache_skip_multiple_images(testdir, skip, args) -> None:
+@pytest.mark.parametrize("args", ["--disallow_unused_cache", []])
+def test_disallow_unused_cache_skip_multiple_images(testdir, skip, args) -> None:
     """Test skips when there are multiple calls to show() in a test."""
     make_cached_images(testdir.tmpdir, name="imcache.png")
     make_cached_images(testdir.tmpdir, name="imcache_1.png")
@@ -567,8 +567,8 @@ def test_allow_unused_cache_skip_multiple_images(testdir, skip, args) -> None:
     assert result.ret == pytest.ExitCode.OK
 
 
-@pytest.mark.parametrize("allow_unused_cache", [True, False])
-def test_allow_unused_cache_name_mismatch(testdir, allow_unused_cache) -> None:
+@pytest.mark.parametrize("disallow_unused_cache", [True, False])
+def test_disallow_unused_cache_name_mismatch(testdir, disallow_unused_cache) -> None:
     """Test cached image doesn't match test name."""
     image_name = "im_cache.png"
     make_cached_images(testdir.tmpdir, name=image_name)
@@ -585,11 +585,11 @@ def test_allow_unused_cache_name_mismatch(testdir, allow_unused_cache) -> None:
             plotter.show()
         """
     )
-    args = "--allow_unused_cache" if allow_unused_cache else []
+    args = "--disallow_unused_cache" if disallow_unused_cache else []
     result = testdir.runpytest(args)
-    if allow_unused_cache:
-        result.stdout.fnmatch_lines("*[Pp]assed*")
-        assert result.ret == pytest.ExitCode.OK
-    else:
+    if disallow_unused_cache:
         result.stderr.fnmatch_lines([*TESTS_FAILED_ERROR_LINES, f"[{image_name!r}]"])
         assert result.ret == pytest.ExitCode.TESTS_FAILED
+    else:
+        result.stdout.fnmatch_lines("*[Pp]assed*")
+        assert result.ret == pytest.ExitCode.OK

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -485,3 +485,25 @@ def test_fail_unused_cache_name_mismatch(testdir) -> None:
 
     result = testdir.runpytest("--fail_unused_cache")
     result.stderr.fnmatch_lines([*TESTS_FAILED_ERROR_LINES, f"[{image_name!r}]"])
+
+
+def test_verify_image_cache_has_no_effect(testdir) -> None:
+    """Test regular usage of the `verify_image_cache` fixture."""
+    testdir.makepyfile(
+        """
+        def test_imcache(verify_image_cache):
+            ...
+        """
+    )
+
+
+    result = testdir.runpytest()
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    result.stdout.fnmatch_lines("*[Pp]assed*")
+    result.stdout.fnmatch_lines(
+        [
+            "*ERROR at teardown of test_imcache*",
+            "*Failed: Fixture `verify_image_cache` is used but no images were generated.",
+            "*Did you forget to call `show` or `plot`, or set `verify_image_cache.skip = True`?."
+        ]
+    )

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -547,7 +547,7 @@ class SkipVerify(LiteralStrEnum):  # noqa: D101
 
 
 class MeshColor(LiteralStrEnum):  # noqa: D101
-    SUCCESS = "red"
+    OK = "red"
     FAIL = "blue"
 
 
@@ -559,7 +559,7 @@ class HasUnusedCache(Enum):  # noqa: D101
         return self.value
 
 
-def _unused_cache_stdout_lines(image_name: str) -> list[str]:
+def _unused_cache_lines(image_name: str) -> list[str]:
     return [
         "*pytest-pyvista ERROR*",
         "Unused cached image file(s) detected (1). The following images are",
@@ -571,21 +571,21 @@ def _unused_cache_stdout_lines(image_name: str) -> list[str]:
 
 
 @pytest.mark.parametrize(
-    ("marker", "skip_verify", "color", "stdout_lines", "stderr_lines", "exit_code", "has_unused_cache"),
+    ("marker", "skip_verify", "color", "stdout_lines", "exit_code", "has_unused_cache"),
     [
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, ["*skipped*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.MACOS, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.WINDOWS, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.IGNORE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.SKIP, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.FALSE),
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [*_unused_cache_stdout_lines("imcache.png")], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [*_unused_cache_stdout_lines("imcache.png")], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [*_unused_cache_stdout_lines("imcache.png")], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
+        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.OK, ["*skipped*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.OK, ["*[Pp]assed*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.MACOS, MeshColor.OK, ["*[Pp]assed*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.WINDOWS, MeshColor.OK, ["*[Pp]assed*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.IGNORE, MeshColor.OK, ["*[Pp]assed*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.SKIP, MeshColor.OK, ["*[Pp]assed*"], pytest.ExitCode.OK, HasUnusedCache.FALSE),
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, ["*FAILED*"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.FALSE),
+        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.OK, [*_unused_cache_lines("imcache.png")], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.OK, [*_unused_cache_lines("imcache.png")], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),
+        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [*_unused_cache_lines("imcache.png")], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),
     ],
-)  # fmt: skip
-def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, stderr_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
+)
+def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
     """Ensure unused cached images are detected correctly."""
     test_name = "foo"
     image_name = test_name + ".png"
@@ -613,7 +613,6 @@ def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines
     result = testdir.runpytest("--disallow_unused_cache")
 
     assert result.ret == exit_code
-    result.stderr.fnmatch_lines(stderr_lines)
     result.stdout.fnmatch_lines(stdout_lines)
 
 
@@ -670,7 +669,7 @@ def test_disallow_unused_cache_name_mismatch(testdir, disallow_unused_cache) -> 
     args = "--disallow_unused_cache" if disallow_unused_cache else []
     result = testdir.runpytest(args)
     if disallow_unused_cache:
-        result.stdout.fnmatch_lines([*_unused_cache_stdout_lines(image_name)])
+        result.stdout.fnmatch_lines([*_unused_cache_lines(image_name)])
         assert result.ret == pytest.ExitCode.TESTS_FAILED
     else:
         result.stdout.fnmatch_lines("*[Pp]assed*")


### PR DESCRIPTION
New CLI option to fix #28 and https://github.com/pyvista/pyvista/issues/7582

This works by storing test results info into ~a global dict~ global sets. The ~dict~ set is populated each time `verify_image_cache` is called, OR whenever a test is skipped during test setup or test execution. This should handle cases where tests are skipped based on OS version or VTK version and not inadvertently fail.