### PR TITLE
Add `allow_useless_fixture` CLI option

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest --allow_useless_fixture --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
+* ``--check_useless_fixture`` fail any tests that use the `verify_image_cache`
+  fixture but don't generated any images."
+
 Test specific flags
 -------------------
 These are attributes of `verify_image_cache`. You can set them as ``True`` if needed

--- a/README.rst
+++ b/README.rst
@@ -118,9 +118,11 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
-* ``--check_useless_fixture`` fail any tests that use the `verify_image_cache`
-  fixture but don't generate any images. See also the ``expect_plot``
-  flag below.
+* Use ``--allow_useless_fixture`` to prevent test failure when the ``verify_image_cache``
+  fixture is used but no images are generated. If no images are generated (i.e. there are
+  no calls made to ``Plotter.show()`` or ``mesh.plot()``), then these tests will fail
+  by default. Set this CLI flag to allow this globally, or use the test-specific flag
+  by the same name below to configure this on a per-test basis.
 
 Test specific flags
 -------------------
@@ -141,11 +143,9 @@ in the beginning of your test function.
 * ``skip``: If you have a test that plots a figure, but you don't want to compare
   its output against the cache, you can skip it with this flag.
 
-* ``expect_plot``: For tests where the ``verify_image_cache`` fixture is used
-  but no images are expected to be generated (e.g. does not call ``Plotter.show()``).
-  This is only useful when ``--check_useless_fixture`` is enabled to prevent an error
-  from being raised when no images are generated. This flag is ``True`` by default,
-  set it to ``False`` if no plots are expected.
+* ``allow_useless_fixture``: Set this flag to ``True`` to prevent test failure when the
+  ``verify_image_cache`` fixture is used but no images are generated. The value of this
+  flag takes precedence over the global flag by the same name (see above).
 
 Configuration
 -------------

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
 * ``--check_useless_fixture`` fail any tests that use the `verify_image_cache`
-  fixture but don't generated any images. See also the ``expect_plot``
+  fixture but don't generate any images. See also the ``expect_plot``
   flag below.
 
 Test specific flags

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,8 @@ These are the flags you can use when calling ``pytest`` in the command line:
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
 * ``--check_useless_fixture`` fail any tests that use the `verify_image_cache`
-  fixture but don't generated any images."
+  fixture but don't generated any images. See also the ``expect_plot``
+  flag below.
 
 Test specific flags
 -------------------
@@ -135,6 +136,12 @@ in the beginning of your test function.
 
 * ``skip``: If you have a test that plots a figure, but you don't want to compare
   its output against the cache, you can skip it with this flag.
+
+* ``expect_plot``: For tests where the ``verify_image_cache`` fixture is used
+  but no images are expected to be generated (e.g. does not call ``Plotter.show()``).
+  This is only useful when ``--check_useless_fixture`` is enabled to prevent an error
+  from being raised when no images are generated. This flag is ``True`` by default,
+  set it to ``False`` if no plots are expected.
 
 Configuration
 -------------


### PR DESCRIPTION
The `verify_image_cache` fixture is sometimes used unnecessarily when no calls to `plot` or show` are made and hence there is nothing to verify. This PR adds an option to check for this and will fail the test's teardown.