### PR TITLE
Add `failed_image_dir` option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,9 +108,8 @@ These are the flags you can use when calling ``pytest`` in the command line:
   directory.  This will override any configuration, see below.
 
 * ``--failed_image_dir <DIR>`` dumps copies of cached and generated test images when
-  there is a warning or error raised. Regression error values are also summarized in
-  a JSON file. This directory is useful for reviewing test failures.
-  This will override any configuration, see below.
+  there is a warning or error raised. This directory is useful for reviewing test
+  failures. This will override any configuration, see below.
 
 * ``--add_missing_images`` adds any missing images from the test run to the cache.
 

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,12 @@ Additionally, to configure the directory that will contain the generated test im
    [tool.pytest.ini_options]
    generated_image_dir = "generated_images"
 
+Similarly, configure the directory that will contain any failed test images:
+
+.. code::
+
+   [tool.pytest.ini_options]
+   failed_image_dir = "failed_images"
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,9 @@ These are the flags you can use when calling ``pytest`` in the command line:
   directory.  This will override any configuration, see below.
 
 * ``--failed_image_dir <DIR>`` dumps copies of cached and generated test images when
-  there is a warning or error raised. This directory is useful for reviewing test
-  failures. This will override any configuration, see below.
+  there is a warning or error raised. Regression error values are also summarized in
+  a JSON file. This directory is useful for reviewing test failures.
+  This will override any configuration, see below.
 
 * ``--add_missing_images`` adds any missing images from the test run to the cache.
 

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
 
+* ``--fail_unused_cache`` report test failure if there are any images in the cache
+  which are not compared to any generated images.
+
 Test specific flags
 -------------------
 These are attributes of `verify_image_cache`. You can set them as ``True`` if needed

--- a/README.rst
+++ b/README.rst
@@ -107,15 +107,16 @@ These are the flags you can use when calling ``pytest`` in the command line:
 * ``--generated_image_dir <DIR>`` dumps all generated test images into the provided
   directory.  This will override any configuration, see below.
 
+* ``--failed_image_dir <DIR>`` dumps copies of cached and generated test images when
+  there is a warning or error raised. This directory is useful for reviewing test
+  failures. This will override any configuration, see below.
+
 * ``--add_missing_images`` adds any missing images from the test run to the cache.
 
 * ``--image_cache_dir <DIR>`` sets the image cache directory.  This will override any
   configuration, see below.
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
-
-* ``--fail_unused_cache`` report test failure if there are any images in the cache
-  which are not compared to any generated images.
 
 Test specific flags
 -------------------

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -284,10 +284,10 @@ def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:
         Path(dirpath).mkdir()
 
 
-def _get_option_from_config_or_ini(pytestconfig, dirname: str) -> str:  # noqa: ANN001
-    gen_dir = pytestconfig.getoption(dirname)
+def _get_option_from_config_or_ini(pytestconfig, option: str) -> str:  # noqa: ANN001
+    gen_dir = pytestconfig.getoption(option)
     if gen_dir is None:
-        gen_dir = pytestconfig.getini(dirname)
+        gen_dir = pytestconfig.getini(option)
     return gen_dir
 
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -315,7 +315,8 @@ def _combine_temp_jsons(parent_dir: Path) -> None:
                 json.dump(dict(sorted(combined_data.items())), f, indent=2)
 
         # Remove tmp dir
-        shutil.rmtree(tmp_jsons_dir)
+        if tmp_jsons_dir.exists():
+            shutil.rmtree(tmp_jsons_dir)
 
 
 @pytest.fixture

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -2,21 +2,16 @@
 
 from __future__ import annotations
 
-from enum import Enum
 import os
 from pathlib import Path
 import platform
 import shutil
-import sys
-from typing import TYPE_CHECKING
-from typing import NamedTuple
+from typing import Literal
+from typing import cast
 import warnings
 
 import pytest
 import pyvista
-
-if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Generator
 
 
 class RegressionError(RuntimeError):
@@ -25,15 +20,6 @@ class RegressionError(RuntimeError):
 
 class RegressionFileNotFound(FileNotFoundError):  # noqa: N818
     """Error when regression file is not found."""
-
-
-class Outcome(Enum):
-    """Outcome of the image verification."""
-
-    SUCCESS = "success"
-    SKIPPED = "skipped"
-    ERROR = "error"
-    WARNING = "warning"
 
 
 def pytest_addoption(parser) -> None:  # noqa: ANN001
@@ -89,11 +75,6 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
         "--reset_only_failed",
         action="store_true",
         help="Reset only the failed images in the PyVista cache.",
-    )
-    group.addoption(
-        "--fail_unused_cache",
-        action="store_true",
-        help="Report test failure if there are any images in the cache which are not compared to any generated images.",
     )
 
 
@@ -166,6 +147,7 @@ class VerifyImageCache:
         var_error_value=1000.0,  # noqa: ANN001
         var_warning_value=1000.0,  # noqa: ANN001
         generated_image_dir=None,  # noqa: ANN001
+        failed_image_dir=None,  # noqa: ANN001
     ) -> None:
         self.test_name = test_name
 
@@ -183,6 +165,7 @@ class VerifyImageCache:
         self.generated_image_dir = generated_image_dir
         if self.generated_image_dir is not None:
             _ensure_dir_exists(self.generated_image_dir, msg_name="generated image dir")
+        self.failed_image_dir = failed_image_dir
 
         self.high_variance_test = False
         self.windows_skip_image_cache = False
@@ -191,7 +174,7 @@ class VerifyImageCache:
         self.skip = False
         self.n_calls = 0
 
-    def __call__(self, plotter):  # noqa: ANN001, ANN204
+    def __call__(self, plotter):  # noqa: ANN001, ANN204, C901, PLR0912
         """
         Either store or validate an image.
 
@@ -201,6 +184,12 @@ class VerifyImageCache:
             The Plotter object that is being closed.
 
         """
+        if self.skip:
+            return
+
+        if self.ignore_image_cache:
+            return
+
         test_name = f"{self.test_name}_{self.n_calls}" if self.n_calls > 0 else self.test_name
         self.n_calls += 1
 
@@ -211,23 +200,17 @@ class VerifyImageCache:
             allowed_error = self.error_value
             allowed_warning = self.warning_value
 
+        # some tests fail when on Windows with OSMesa
+        if os.name == "nt" and self.windows_skip_image_cache:
+            return
+        # high variation for MacOS
+        if platform.system() == "Darwin" and self.macos_skip_image_cache:
+            return
+
         # cached image name. We remove the first 5 characters of the function name
         # "test_" to get the name for the image.
-        image_name = _image_name_from_test_name(test_name)
+        image_name = test_name[5:] + ".png"
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
-        gen_image_filename = None
-
-        skip_windows = os.name == "nt" and self.windows_skip_image_cache
-        skip_macos = platform.system() == "Darwin" and self.macos_skip_image_cache
-        if self.skip or self.ignore_image_cache or skip_windows or skip_macos:
-            # Log result as skipped
-            _store_result(
-                test_name=test_name,
-                outcome=Outcome.SKIPPED,
-                cached_filename=image_name,
-                generated_filename=gen_image_filename,
-            )
-            return
 
         if not os.path.isfile(image_filename) and self.fail_extra_image_cache and not self.reset_image_cache:  # noqa: PTH113
             # Make sure this doesn't get called again if this plotter doesn't close properly
@@ -245,7 +228,8 @@ class VerifyImageCache:
         error = pyvista.compare_images(image_filename, plotter)
 
         if error > allowed_error:
-            _store_result(test_name=test_name, outcome=Outcome.ERROR, cached_filename=image_filename, generated_filename=gen_image_filename)
+            if self.failed_image_dir is not None:
+                self._save_failed_test_images("error", plotter, image_name)
             if self.reset_only_failed:
                 warnings.warn(  # noqa: B028
                     f"{test_name} Exceeded image regression error of "
@@ -259,10 +243,30 @@ class VerifyImageCache:
                 msg = f"{test_name} Exceeded image regression error of {allowed_error} with an image error equal to: {error}"
                 raise RegressionError(msg)
         if error > allowed_warning:
-            _store_result(test_name=test_name, outcome=Outcome.WARNING, cached_filename=image_filename, generated_filename=gen_image_filename)
+            if self.failed_image_dir is not None:
+                self._save_failed_test_images("warning", plotter, image_name)
             warnings.warn(f"{test_name} Exceeded image regression warning of {allowed_warning} with an image error of {error}")  # noqa: B028
-        else:
-            _store_result(test_name=test_name, outcome=Outcome.SUCCESS, cached_filename=image_filename, generated_filename=gen_image_filename)
+
+    def _save_failed_test_images(self, error_or_warning: Literal["error", "warning"], plotter: pyvista.Plotter, image_name: str) -> None:
+        def _make_failed_test_image_dir(
+            errors_or_warnings: Literal["errors", "warnings"], from_cache_or_test: Literal["from_cache", "from_test"]
+        ) -> Path:
+            """Save test image from cache or test to the failed image dir."""
+            _ensure_dir_exists(self.failed_image_dir, msg_name="failed image dir")
+            Path(self.failed_image_dir, errors_or_warnings).mkdir(exist_ok=True)
+
+            dest_dir = Path(self.failed_image_dir, errors_or_warnings, from_cache_or_test)
+            dest_dir.mkdir(exist_ok=True)
+            return dest_dir
+
+        error_dirname = cast("Literal['errors', 'warnings']", error_or_warning + "s")
+        from_test_dir = _make_failed_test_image_dir(error_dirname, "from_test")
+        plotter.screenshot(Path(from_test_dir, image_name))
+
+        cached_image = Path(self.cache_dir, image_name)
+        if cached_image.is_file():
+            from_cache_dir = _make_failed_test_image_dir(error_dirname, "from_cache")
+            shutil.copy(cached_image, Path(from_cache_dir, image_name))
 
 
 def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:
@@ -279,124 +283,6 @@ def _get_dir_from_config_or_ini(pytestconfig, dirname: str) -> str:  # noqa: ANN
     return gen_dir
 
 
-def _image_name_from_test_name(test_name: str) -> str:
-    return test_name[5:] + ".png"
-
-
-def _test_name_from_image_name(image_name: str) -> str:
-    def remove_suffix(s: str) -> str:
-        """Remove integer and png suffix."""
-        no_png_ext = s[:-4]
-        parts = no_png_ext.split("_")
-        if len(parts) > 1:
-            try:
-                int(parts[-1])
-                parts = parts[:-1]  # Remove the integer suffix
-            except ValueError:
-                pass  # Last part is not an integer; do nothing
-        return "_".join(parts)
-
-    return "test_" + remove_suffix(image_name)
-
-
-class _ResultTuple(NamedTuple):
-    outcome: Outcome
-    cached_filename: str
-    generated_filename: str | None
-
-
-RESULTS = {}
-
-
-def _store_result(*, test_name: str, outcome: Outcome, cached_filename: str, generated_filename: str | None = None) -> None:
-    result = _ResultTuple(
-        outcome=outcome,
-        cached_filename=str(Path(cached_filename).name),
-        generated_filename=str(Path(generated_filename).name) if generated_filename else None,
-    )
-    RESULTS[test_name] = result
-
-
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
-    """Store test results for skipped tests."""
-    outcome = yield
-    if outcome:
-        rep = outcome.get_result()
-
-        # Log if test was skipped
-        if rep.when in ["call", "setup"] and rep.skipped:
-            test_name = item.name
-            _store_result(
-                test_name=test_name,
-                outcome=Outcome.SKIPPED,
-                cached_filename=_image_name_from_test_name(test_name),
-                generated_filename=None,
-            )
-
-
-@pytest.hookimpl
-def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
-    """Execute after the whole test run completes."""
-    config = session.config
-
-    fail_unused_cache = config.getoption("fail_unused_cache")
-    image_cache_dir = _get_dir_from_config_or_ini(config, "image_cache_dir")
-    failed_image_dir = _get_dir_from_config_or_ini(config, "failed_image_dir")
-    generated_image_dir = _get_dir_from_config_or_ini(config, "generated_image_dir")
-
-    if image_cache_dir and fail_unused_cache:
-        cache_path = Path(image_cache_dir)
-        cached_files = {f.name for f in cache_path.glob("*.png")}
-        tested_files = {result.cached_filename for result in RESULTS.values()}
-        unused = cached_files - tested_files
-
-        # Exclude images from skipped tests where multiple images are generated
-        unused_skipped = unused.copy()
-        for image_name in unused:
-            test_name = _test_name_from_image_name(image_name)
-            result = RESULTS.get(test_name)
-            if result and result.outcome == Outcome.SKIPPED:
-                unused_skipped.remove(image_name)
-
-        if unused_skipped:
-            msg = (
-                f"\npytest-pyvista: ERROR: Unused cached image file(s) detected ({len(unused_skipped)}).\n"
-                f"The following images were not generated or skipped by any of the tests:\n"
-                f"{sorted(unused_skipped)}\n"
-            )
-            # Print the message so it appears in the output
-            sys.stderr.write(msg)
-            sys.stderr.flush()
-
-            session.exitstatus = pytest.ExitCode.TESTS_FAILED
-
-    if failed_image_dir:
-        for result in RESULTS.values():
-            if result.outcome in [Outcome.WARNING, Outcome.ERROR]:
-                cached_image_path = Path(image_cache_dir, result.cached_filename)
-                if cached_image_path.is_file():
-                    _ensure_dir_exists(failed_image_dir, msg_name="failed image dir")
-                    _save_failed_test_image(cached_image_path, result.outcome, image_cache_dir, failed_image_dir)
-                if result.generated_filename:
-                    _ensure_dir_exists(failed_image_dir, msg_name="failed image dir")
-                    generated_image_path = Path(generated_image_dir, result.generated_filename)
-                    _save_failed_test_image(generated_image_path, result.outcome, image_cache_dir, failed_image_dir)
-
-    RESULTS.clear()
-
-
-def _save_failed_test_image(source_image_path: Path, outcome: Outcome, image_cache_dir: str, failed_image_dir: str) -> None:
-    """Save test image from cache or test to the failed image dir."""
-    parent_dir = Path(outcome.name.lower() + "s")
-    dest_dirname = "from_cache" if Path(source_image_path).parent == Path(image_cache_dir) else "from_test"
-    Path(failed_image_dir, parent_dir).mkdir(exist_ok=True)
-    dest_dir = Path(failed_image_dir, parent_dir, dest_dirname)
-    dest_dir.mkdir(exist_ok=True)
-    dest_path = Path(dest_dir, Path(source_image_path).name)
-    shutil.copy(source_image_path, dest_path)
-
-
 @pytest.fixture
 def verify_image_cache(request, pytestconfig):  # noqa: ANN001, ANN201
     """Checks cached images against test images for PyVista."""  # noqa: D401
@@ -409,8 +295,9 @@ def verify_image_cache(request, pytestconfig):  # noqa: ANN001, ANN201
 
     cache_dir = _get_dir_from_config_or_ini(pytestconfig, "image_cache_dir")
     gen_dir = _get_dir_from_config_or_ini(pytestconfig, "generated_image_dir")
+    failed_dir = _get_dir_from_config_or_ini(pytestconfig, "failed_image_dir")
 
-    verify_image_cache = VerifyImageCache(request.node.name, cache_dir, generated_image_dir=gen_dir)
+    verify_image_cache = VerifyImageCache(request.node.name, cache_dir, generated_image_dir=gen_dir, failed_image_dir=failed_dir)
     pyvista.global_theme.before_close_callback = verify_image_cache
 
     def reset() -> None:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -223,6 +223,7 @@ class VerifyImageCache:
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
 
         if not os.path.isfile(image_filename) and self.fail_extra_image_cache and not self.reset_image_cache:  # noqa: PTH113
+            self._save_failed_test_images("error", plotter, image_name)
             remove_plotter_close_callback()
             msg = f"{image_filename} does not exist in image cache"
             raise RegressionFileNotFound(msg)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -282,7 +282,7 @@ def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:
         Path(dirpath).mkdir()
 
 
-def _get_dir_from_config_or_ini(pytestconfig, dirname: str) -> str:  # noqa: ANN001
+def _get_option_from_config_or_ini(pytestconfig, dirname: str) -> str:  # noqa: ANN001
     gen_dir = pytestconfig.getoption(dirname)
     if gen_dir is None:
         gen_dir = pytestconfig.getini(dirname)
@@ -299,9 +299,9 @@ def verify_image_cache(request, pytestconfig):  # noqa: ANN001, ANN201
     VerifyImageCache.add_missing_images = pytestconfig.getoption("add_missing_images")
     VerifyImageCache.reset_only_failed = pytestconfig.getoption("reset_only_failed")
 
-    cache_dir = _get_dir_from_config_or_ini(pytestconfig, "image_cache_dir")
-    gen_dir = _get_dir_from_config_or_ini(pytestconfig, "generated_image_dir")
-    failed_dir = _get_dir_from_config_or_ini(pytestconfig, "failed_image_dir")
+    cache_dir = _get_option_from_config_or_ini(pytestconfig, "image_cache_dir")
+    gen_dir = _get_option_from_config_or_ini(pytestconfig, "generated_image_dir")
+    failed_dir = _get_option_from_config_or_ini(pytestconfig, "failed_image_dir")
 
     verify_image_cache = VerifyImageCache(request.node.name, cache_dir, generated_image_dir=gen_dir, failed_image_dir=failed_dir)
     pyvista.global_theme.before_close_callback = verify_image_cache

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -267,11 +267,8 @@ class VerifyImageCache:
             errors_or_warnings: Literal["errors", "warnings"], from_cache_or_test: Literal["from_cache", "from_test"]
         ) -> Path:
             _ensure_dir_exists(self.failed_image_dir, msg_name="failed image dir")
-            errors_or_warnings_dir = Path(self.failed_image_dir, errors_or_warnings)
-            errors_or_warnings_dir.mkdir(exist_ok=True)
-
-            dest_dir = errors_or_warnings_dir / from_cache_or_test
-            dest_dir.mkdir(exist_ok=True)
+            dest_dir = Path(self.failed_image_dir, errors_or_warnings, from_cache_or_test)
+            dest_dir.mkdir(exist_ok=True, parents=True)
             return dest_dir
 
         error_dirname = cast("Literal['errors', 'warnings']", error_or_warning + "s")
@@ -289,7 +286,7 @@ def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:
     if not Path(dirpath).is_dir():
         msg = f"pyvista test {msg_name}: {dirpath} does not yet exist.  Creating dir."
         warnings.warn(msg, stacklevel=2)
-        Path(dirpath).mkdir()
+        Path(dirpath).mkdir(parents=True)
 
 
 def _get_option_from_config_or_ini(pytestconfig, option: str) -> str:  # noqa: ANN001

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -6,12 +6,16 @@ import os
 from pathlib import Path
 import platform
 import shutil
+from typing import TYPE_CHECKING
 from typing import Literal
 from typing import cast
 import warnings
 
 import pytest
 import pyvista
+
+if TYPE_CHECKING:
+    from pyvista import Plotter
 
 
 class RegressionError(RuntimeError):
@@ -43,7 +47,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
     )
     parser.addini(
         "generated_image_dir",
-        default="generated_image_dir",
+        default=None,
         help="Path to dump test images from the current run.",
     )
     group.addoption(
@@ -53,7 +57,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
     )
     parser.addini(
         "failed_image_dir",
-        default="failed_image_dir",
+        default=None,
         help="Path to dump images from failed tests from the current run.",
     )
     group.addoption(
@@ -229,16 +233,17 @@ class VerifyImageCache:
         if self.generated_image_dir is not None:
             gen_image_filename = os.path.join(self.generated_image_dir, image_name)  # noqa: PTH118
             plotter.screenshot(gen_image_filename)
-            if not Path(image_filename).is_file():
-                # Image comparison will fail, so save image before error
-                self._save_failed_test_images("error", image_name)
-                remove_plotter_close_callback()
+
+        if self.failed_image_dir is not None and not Path(image_filename).is_file():
+            # Image comparison will fail, so save image before error
+            self._save_failed_test_images("error", plotter, image_name)
+            remove_plotter_close_callback()
 
         error = pyvista.compare_images(image_filename, plotter)
 
         if error > allowed_error:
             if self.failed_image_dir is not None:
-                self._save_failed_test_images("error", image_name)
+                self._save_failed_test_images("error", plotter, image_name)
             if self.reset_only_failed:
                 warnings.warn(  # noqa: B028
                     f"{test_name} Exceeded image regression error of "
@@ -252,10 +257,10 @@ class VerifyImageCache:
                 raise RegressionError(msg)
         if error > allowed_warning:
             if self.failed_image_dir is not None:
-                self._save_failed_test_images("warning", image_name)
+                self._save_failed_test_images("warning", plotter, image_name)
             warnings.warn(f"{test_name} Exceeded image regression warning of {allowed_warning} with an image error of {error}")  # noqa: B028
 
-    def _save_failed_test_images(self, error_or_warning: Literal["error", "warning"], image_name: str) -> None:
+    def _save_failed_test_images(self, error_or_warning: Literal["error", "warning"], plotter: Plotter, image_name: str) -> None:
         """Save test image from cache and from test to the failed image dir."""
 
         def _make_failed_test_image_dir(
@@ -271,17 +276,13 @@ class VerifyImageCache:
 
         error_dirname = cast("Literal['errors', 'warnings']", error_or_warning + "s")
 
-        if self.generated_image_dir is not None:
-            generated_image = Path(self.generated_image_dir, image_name)
-            if generated_image.is_file():
-                from_test_dir = _make_failed_test_image_dir(error_dirname, "from_test")
-                shutil.copy(generated_image, Path(from_test_dir, image_name))
+        from_test_dir = _make_failed_test_image_dir(error_dirname, "from_test")
+        plotter.screenshot(from_test_dir / image_name)
 
-        if self.cache_dir is not None:
-            cached_image = Path(self.cache_dir, image_name)
-            if cached_image.is_file():
-                from_cache_dir = _make_failed_test_image_dir(error_dirname, "from_cache")
-                shutil.copy(cached_image, Path(from_cache_dir, image_name))
+        cached_image = Path(self.cache_dir, image_name)
+        if cached_image.is_file():
+            from_cache_dir = _make_failed_test_image_dir(error_dirname, "from_cache")
+            shutil.copy(cached_image, from_cache_dir / image_name)
 
 
 def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from enum import Enum
 import os
+from pathlib import Path
 import platform
+import sys
+from typing import TYPE_CHECKING
+from typing import NamedTuple
 import warnings
 
 import pytest
 import pyvista
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
 
 
 class RegressionError(RuntimeError):
@@ -16,6 +24,15 @@ class RegressionError(RuntimeError):
 
 class RegressionFileNotFound(FileNotFoundError):  # noqa: N818
     """Error when regression file is not found."""
+
+
+class Outcome(Enum):
+    """Outcome of the image verification."""
+
+    SUCCESS = "success"
+    SKIPPED = "skipped"
+    ERROR = "error"
+    WARNING = "warning"
 
 
 def pytest_addoption(parser) -> None:  # noqa: ANN001
@@ -61,6 +78,11 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
         "--reset_only_failed",
         action="store_true",
         help="Reset only the failed images in the PyVista cache.",
+    )
+    group.addoption(
+        "--fail_unused_cache",
+        action="store_true",
+        help="Report test failure if there are any images in the cache which are not compared to any generated images.",
     )
 
 
@@ -159,7 +181,7 @@ class VerifyImageCache:
         self.skip = False
         self.n_calls = 0
 
-    def __call__(self, plotter):  # noqa: ANN001, ANN204, C901, PLR0912
+    def __call__(self, plotter):  # noqa: ANN001, ANN204
         """
         Either store or validate an image.
 
@@ -169,12 +191,6 @@ class VerifyImageCache:
             The Plotter object that is being closed.
 
         """
-        if self.skip:
-            return
-
-        if self.ignore_image_cache:
-            return
-
         test_name = f"{self.test_name}_{self.n_calls}" if self.n_calls > 0 else self.test_name
         self.n_calls += 1
 
@@ -185,17 +201,23 @@ class VerifyImageCache:
             allowed_error = self.error_value
             allowed_warning = self.warning_value
 
-        # some tests fail when on Windows with OSMesa
-        if os.name == "nt" and self.windows_skip_image_cache:
-            return
-        # high variation for MacOS
-        if platform.system() == "Darwin" and self.macos_skip_image_cache:
-            return
-
         # cached image name. We remove the first 5 characters of the function name
         # "test_" to get the name for the image.
-        image_name = test_name[5:] + ".png"
+        image_name = _image_name_from_test_name(test_name)
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
+        gen_image_filename = None
+
+        skip_windows = os.name == "nt" and self.windows_skip_image_cache
+        skip_macos = platform.system() == "Darwin" and self.macos_skip_image_cache
+        if self.skip or self.ignore_image_cache or skip_windows or skip_macos:
+            # Log result as skipped
+            _store_result(
+                test_name=test_name,
+                outcome=Outcome.SKIPPED,
+                cached_filename=image_name,
+                generated_filename=gen_image_filename,
+            )
+            return
 
         if not os.path.isfile(image_filename) and self.fail_extra_image_cache and not self.reset_image_cache:  # noqa: PTH113
             # Make sure this doesn't get called again if this plotter doesn't close properly
@@ -213,6 +235,7 @@ class VerifyImageCache:
         error = pyvista.compare_images(image_filename, plotter)
 
         if error > allowed_error:
+            _store_result(test_name=test_name, outcome=Outcome.ERROR, cached_filename=image_filename, generated_filename=gen_image_filename)
             if self.reset_only_failed:
                 warnings.warn(  # noqa: B028
                     f"{test_name} Exceeded image regression error of "
@@ -226,7 +249,106 @@ class VerifyImageCache:
                 msg = f"{test_name} Exceeded image regression error of {allowed_error} with an image error equal to: {error}"
                 raise RegressionError(msg)
         if error > allowed_warning:
+            _store_result(test_name=test_name, outcome=Outcome.WARNING, cached_filename=image_filename, generated_filename=gen_image_filename)
             warnings.warn(f"{test_name} Exceeded image regression warning of {allowed_warning} with an image error of {error}")  # noqa: B028
+        else:
+            _store_result(test_name=test_name, outcome=Outcome.SUCCESS, cached_filename=image_filename, generated_filename=gen_image_filename)
+
+
+def _image_name_from_test_name(test_name: str) -> str:
+    return test_name[5:] + ".png"
+
+
+def _test_name_from_image_name(image_name: str) -> str:
+    def remove_suffix(s: str) -> str:
+        """Remove integer and png suffix."""
+        no_png_ext = s[:-4]
+        parts = no_png_ext.split("_")
+        if len(parts) > 1:
+            try:
+                int(parts[-1])
+                parts = parts[:-1]  # Remove the integer suffix
+            except ValueError:
+                pass  # Last part is not an integer; do nothing
+        return "_".join(parts)
+
+    return "test_" + remove_suffix(image_name)
+
+
+class _ResultTuple(NamedTuple):
+    outcome: Outcome
+    cached_filename: str
+    generated_filename: str | None
+
+
+RESULTS = {}
+
+
+def _store_result(*, test_name: str, outcome: Outcome, cached_filename: str, generated_filename: str | None = None) -> None:
+    result = _ResultTuple(
+        outcome=outcome,
+        cached_filename=str(Path(cached_filename).name),
+        generated_filename=str(Path(generated_filename).name) if generated_filename else None,
+    )
+    RESULTS[test_name] = result
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
+    """Store test results for skipped tests."""
+    outcome = yield
+    if outcome:
+        rep = outcome.get_result()
+
+        # Log if test was skipped
+        if rep.when in ["call", "setup"] and rep.skipped:
+            test_name = item.name
+            _store_result(
+                test_name=test_name,
+                outcome=Outcome.SKIPPED,
+                cached_filename=_image_name_from_test_name(test_name),
+                generated_filename=None,
+            )
+
+
+@pytest.hookimpl
+def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001
+    """Execute after the whole test run completes."""
+    config = session.config
+
+    image_cache_dir = config.getoption("image_cache_dir")
+    fail_unused_cache = config.getoption("fail_unused_cache")
+
+    if image_cache_dir is None:
+        image_cache_dir = config.getini("image_cache_dir")
+
+    if image_cache_dir and fail_unused_cache:
+        cache_path = Path(image_cache_dir)
+        cached_files = {f.name for f in cache_path.glob("*.png")}
+        tested_files = {result.cached_filename for result in RESULTS.values()}
+        unused = cached_files - tested_files
+
+        # Exclude images from skipped tests where multiple images are generated
+        unused_skipped = unused.copy()
+        for image_name in unused:
+            test_name = _test_name_from_image_name(image_name)
+            result = RESULTS.get(test_name)
+            if result and result.outcome == Outcome.SKIPPED:
+                unused_skipped.remove(image_name)
+
+        if unused_skipped:
+            msg = (
+                f"\npytest-pyvista: ERROR: Unused cached image file(s) detected ({len(unused_skipped)}).\n"
+                f"The following images were not generated or skipped by any of the tests:\n"
+                f"{sorted(unused_skipped)}\n"
+            )
+            # Print the message so it appears in the output
+            sys.stderr.write(msg)
+            sys.stderr.flush()
+
+            session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+    RESULTS.clear()
 
 
 @pytest.fixture

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -223,7 +223,8 @@ class VerifyImageCache:
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
 
         if not os.path.isfile(image_filename) and self.fail_extra_image_cache and not self.reset_image_cache:  # noqa: PTH113
-            self._save_failed_test_images("error", plotter, image_name)
+            if self.failed_image_dir is not None:
+                self._save_failed_test_images("error", plotter, image_name)
             remove_plotter_close_callback()
             msg = f"{image_filename} does not exist in image cache"
             raise RegressionFileNotFound(msg)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -292,10 +292,10 @@ def _ensure_dir_exists(dirpath: str, msg_name: str) -> None:
 
 
 def _get_option_from_config_or_ini(pytestconfig, option: str) -> str:  # noqa: ANN001
-    gen_dir = pytestconfig.getoption(option)
-    if gen_dir is None:
-        gen_dir = pytestconfig.getini(option)
-    return gen_dir
+    value = pytestconfig.getoption(option)
+    if value is None:
+        value = pytestconfig.getini(option)
+    return value
 
 
 @pytest.fixture

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -254,14 +254,16 @@ class VerifyImageCache:
             warnings.warn(f"{test_name} Exceeded image regression warning of {allowed_warning} with an image error of {error}")  # noqa: B028
 
     def _save_failed_test_images(self, error_or_warning: Literal["error", "warning"], plotter: pyvista.Plotter, image_name: str) -> None:
+        """Save test image from cache or test to the failed image dir."""
+
         def _make_failed_test_image_dir(
             errors_or_warnings: Literal["errors", "warnings"], from_cache_or_test: Literal["from_cache", "from_test"]
         ) -> Path:
-            """Save test image from cache or test to the failed image dir."""
             _ensure_dir_exists(self.failed_image_dir, msg_name="failed image dir")
-            Path(self.failed_image_dir, errors_or_warnings).mkdir(exist_ok=True)
+            errors_or_warnings_dir = Path(self.failed_image_dir, errors_or_warnings)
+            errors_or_warnings_dir.mkdir(exist_ok=True)
 
-            dest_dir = Path(self.failed_image_dir, errors_or_warnings, from_cache_or_test)
+            dest_dir = errors_or_warnings_dir / from_cache_or_test
             dest_dir.mkdir(exist_ok=True)
             return dest_dir
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # noqa: D100
 
 import filecmp
+import json
 import os
 
 import pytest
@@ -394,3 +395,17 @@ def test_failed_image_dir(testdir, outcome) -> None:
 
         assert (failed_image_dir_path / expected_subdir / "from_test").isdir()
         assert (failed_image_dir_path / expected_subdir / "from_test" / cached_image_name).isfile()
+
+        # Test error is reported in JSON file
+        json_file = failed_image_dir_path / expected_subdir / (expected_subdir + ".json")
+        assert json_file.isfile()
+        errors = json.load(json_file)
+        assert len(errors) == 1
+        assert list(errors.keys()) == [cached_image_name]
+        reported_error = next(iter(errors.values()))
+        error_threshold = 500.0
+        warning_threshold = 200.0
+        if outcome == "error":
+            assert reported_error > error_threshold
+        else:
+            assert warning_threshold < reported_error < error_threshold

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -351,7 +351,7 @@ def test_file_not_found(testdir) -> None:
 
 @pytest.mark.parametrize("outcome", ["error", "warning", "success"])
 def test_failed_image_dir(testdir, outcome) -> None:
-    """Test regular usage of the `verify_image_cache` fixture."""
+    """Test usage of the `failed_image_dir` option."""
     cached_image_name = "imcache.png"
     make_cached_images(testdir.tmpdir)
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1,7 +1,6 @@
 from __future__ import annotations  # noqa: D100
 
 import filecmp
-import json
 import os
 
 import pytest
@@ -395,17 +394,3 @@ def test_failed_image_dir(testdir, outcome) -> None:
 
         assert (failed_image_dir_path / expected_subdir / "from_test").isdir()
         assert (failed_image_dir_path / expected_subdir / "from_test" / cached_image_name).isfile()
-
-        # Test error is reported in JSON file
-        json_file = failed_image_dir_path / expected_subdir / (expected_subdir + ".json")
-        assert json_file.isfile()
-        errors = json.load(json_file)
-        assert len(errors) == 1
-        assert list(errors.keys()) == [cached_image_name]
-        reported_error = next(iter(errors.values()))
-        error_threshold = 500.0
-        warning_threshold = 200.0
-        if outcome == "error":
-            assert reported_error > error_threshold
-        else:
-            assert warning_threshold < reported_error < error_threshold

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -372,11 +372,12 @@ def test_failed_image_dir(testdir, outcome, make_cache) -> None:
         """
     )
     dirname = "failed_image_dir"
+    result = testdir.runpytest("--failed_image_dir", dirname)
+
     failed_image_dir_path = testdir.tmpdir / dirname
     if outcome == "success":
         assert not failed_image_dir_path.isdir()
     else:
-        result = testdir.runpytest("--failed_image_dir", dirname)
         result.stdout.fnmatch_lines("*UserWarning: pyvista test failed image dir: failed_image_dir does not yet exist.  Creating dir.")
         if make_cache:
             result.stdout.fnmatch_lines(f"*Exceeded image regression {outcome}*")

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -55,6 +55,10 @@ def test_verify_image_cache(testdir) -> None:
     result = testdir.runpytest("--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
+    assert (testdir.tmpdir / "image_cache_dir").isdir()
+    assert not (testdir.tmpdir / "generated_image_dir").isdir()
+    assert not (testdir.tmpdir / "failed_image_dir").isdir()
+
 
 def test_verify_image_cache_fail_regression(testdir) -> None:
     """Test regression of the `verify_image_cache` fixture."""

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # noqa: D100
 
-from enum import Enum
 import filecmp
 import os
 
@@ -21,7 +20,7 @@ def test_arguments(testdir) -> None:
 
         """
     )
-    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--fail_extra_image_cache", "--fail_unused_cache")
+    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -348,141 +347,6 @@ def test_file_not_found(testdir) -> None:
     result = testdir.runpytest("--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*RegressionFileNotFound*")
     result.stdout.fnmatch_lines("*does not exist in image cache*")
-
-
-class LiteralStrEnum(str, Enum):  # noqa: D101
-    def __str__(self) -> str:  # noqa: D105
-        return str(self.value)
-
-
-class PytestMark(LiteralStrEnum):  # noqa: D101
-    NONE = ""
-    SKIP = "@pytest.mark.skip"
-
-
-class SkipVerify(LiteralStrEnum):  # noqa: D101
-    NONE = ""
-    MACOS = "verify_image_cache.macos_skip_image_cache"
-    WINDOWS = "verify_image_cache.windows_skip_image_cache"
-    IGNORE = "verify_image_cache.ignore_image_cache"
-    SKIP = "verify_image_cache.skip"
-
-
-class MeshColor(LiteralStrEnum):  # noqa: D101
-    SUCCESS = "red"
-    FAIL = "blue"
-
-
-class HasUnusedCache(Enum):  # noqa: D101
-    TRUE = True
-    FALSE = False
-
-    def __bool__(self) -> bool:  # noqa: D105
-        return self.value
-
-
-TESTS_FAILED_ERROR_LINES = [
-    "pytest-pyvista: ERROR: Unused cached image file(s) detected (1).",
-    "The following images were not generated or skipped by any of the tests:",
-]
-
-
-@pytest.mark.parametrize(
-    ("marker", "skip_verify", "color", "stdout_lines", "stderr_lines", "exit_code", "has_unused_cache"),
-    [
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, ["*skipped*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.MACOS, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.WINDOWS, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.IGNORE, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.SKIP, MeshColor.SUCCESS, ["*[Pp]assed*"], [], pytest.ExitCode.OK, HasUnusedCache.FALSE),
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, ["*FAILED*"], [], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.FALSE),
-        (PytestMark.SKIP, SkipVerify.NONE, MeshColor.SUCCESS, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.SUCCESS, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
-        (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [], [*TESTS_FAILED_ERROR_LINES, "['imcache.png']"], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),  # noqa: E501
-    ],
-)  # fmt: skip
-def test_fail_unused_cache(testdir, marker, skip_verify, color, stdout_lines, stderr_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
-    """Ensure unused cached images are detected correctly."""
-    test_name = "foo"
-    image_name = test_name + ".png"
-    image_cache_dir = "image_cache_dir"
-
-    make_cached_images(testdir.tmpdir, image_cache_dir, image_name)
-    if has_unused_cache:
-        make_cached_images(testdir.tmpdir)
-
-    testdir.makepyfile(
-        f"""
-        import pytest
-        import pyvista as pv
-        pv.OFF_SCREEN = True
-        {marker}
-        def test_{test_name}(verify_image_cache):
-            {skip_verify}
-            sphere = pv.Sphere()
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="{color}")
-            plotter.show()
-        """
-    )
-
-    result = testdir.runpytest("--fail_unused_cache")
-
-    assert result.ret == exit_code
-    result.stderr.fnmatch_lines(stderr_lines)
-    result.stdout.fnmatch_lines(stdout_lines)
-
-
-@pytest.mark.parametrize("skip", [True, False])
-def test_fail_unused_cache_skip_multiple_images(testdir, skip) -> None:
-    """Test skips when there are multiple calls to show() in a test."""
-    make_cached_images(testdir.tmpdir, name="imcache.png")
-    make_cached_images(testdir.tmpdir, name="imcache_1.png")
-
-    marker = "@pytest.mark.skip" if skip else ""
-    testdir.makepyfile(
-        f"""
-        import pytest
-        import pyvista as pv
-        pv.OFF_SCREEN = True
-        {marker}
-        def test_imcache(verify_image_cache):
-            sphere = pv.Sphere()
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="red")
-            plotter.show()
-            #
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="red")
-            plotter.show()
-        """
-    )
-
-    result = testdir.runpytest("--fail_unused_cache")
-    expected = "*skipped*" if skip else "*[Pp]assed*"
-    result.stdout.fnmatch_lines(expected)
-
-
-def test_fail_unused_cache_name_mismatch(testdir) -> None:
-    """Test cached image doesn't match test name."""
-    image_name = "im_cache.png"
-    make_cached_images(testdir.tmpdir, name=image_name)
-
-    testdir.makepyfile(
-        """
-        import pyvista as pv
-        pv.OFF_SCREEN = True
-        def test_imcache(verify_image_cache):
-            sphere = pv.Sphere()
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="red")
-            plotter.show()
-        """
-    )
-
-    result = testdir.runpytest("--fail_unused_cache")
-    result.stderr.fnmatch_lines([*TESTS_FAILED_ERROR_LINES, f"[{image_name!r}]"])
 
 
 @pytest.mark.parametrize("outcome", ["error", "warning", "success"])


### PR DESCRIPTION
New option to save any tests where a warning or error was generated. 

Currently, if a test fails and we want to review the results, we have to manually search for the generated image in the `generated_image_dir` as well as manually search for the cached image in the `cache_image_dir`. This can be challenging with 500+ images in the pyvista repo. With this PR, these results are captured and copied into a separate easy-to-review location in `failed_image_dir`. This is similar to how the documentation image tests currently work for pyvista.

~This PR builds upon code from #169~