### PR TITLE
Set default generated image dir to `None`

### DIFF
--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
     )
     parser.addini(
         "generated_image_dir",
-        default="generated_image_dir",
+        default=None,
         help="Path to dump test images from the current run.",
     )
     group.addoption(

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -54,6 +54,9 @@ def test_verify_image_cache(testdir) -> None:
     result = testdir.runpytest("--fail_extra_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
+    assert (testdir.tmpdir / "image_cache_dir").isdir()
+    assert not (testdir.tmpdir / "generated_image_dir").isdir()
+
 
 def test_verify_image_cache_fail_regression(testdir) -> None:
     """Test regression of the `verify_image_cache` fixture."""


### PR DESCRIPTION
The docs state no images are saved unless this option is set:
https://github.com/pyvista/pytest-pyvista/blob/10952115b004451f5afa8382ff6dd3ccb022d103/pytest_pyvista/pytest_pyvista.py#L100-L102

Though, this is for `VerifyImageCache.__init__` (not sure if this class is used this way without the fixture / pytest options). The README is less clear about this:
https://github.com/pyvista/pytest-pyvista/blob/10952115b004451f5afa8382ff6dd3ccb022d103/README.rst?plain=1#L107-L108

But it seems to me that the intention of this option was for it to originally be optional. When this option was initially added in https://github.com/pyvista/pytest-pyvista/pull/22, it was not enabled by default

But, when the `pytest.ini` option was added in https://github.com/pyvista/pytest-pyvista/pull/96, this added a default value, which means this dir is never `None`, and hence images are _always_ saved.
https://github.com/pyvista/pytest-pyvista/blob/10952115b004451f5afa8382ff6dd3ccb022d103/pytest_pyvista/pytest_pyvista.py#L40-L44

This PR reverts this change and makes generating the directory optional once again.