### PR TITLE
Add `allow_unused_generated` option as a replacement for `fail_extra_image_cache`

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --allow_unused_generated -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: pyvista
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest --fail_extra_image_cache -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
+        run: xvfb-run python -m pytest --allow_unused_generated -v --generated_image_dir gen_dir tests/plotting/test_plotting.py
         working-directory: pyvista
 
       - name: Upload generated image artifact

--- a/README.rst
+++ b/README.rst
@@ -100,9 +100,6 @@ These are the flags you can use when calling ``pytest`` in the command line:
 
 * You can use ``--ignore_image_cache`` if you want to
   temporarily ignore regression testing, e.g. on a particular CI action.
-
-* When using ``--fail_extra_image_cache`` if there is an extra image in the
-  cache, it will report as an error.
   
 * ``--generated_image_dir <DIR>`` dumps all generated test images into the provided
   directory.  This will override any configuration, see below.
@@ -113,6 +110,12 @@ These are the flags you can use when calling ``pytest`` in the command line:
   configuration, see below.
 
 * ``--reset_only_failed`` reset the image cache of the failed tests only.
+
+* Use ``--allow_unused_generated`` to prevent an error from being raised when a
+  test image is generated but not used. A test image is considered "used" if it has a
+  corresponding cached image to compare against, or is used to reset or update the
+  cache (e.g. if using ``--add_missing_images``). Otherwise, an error is raised by
+  default.
 
 Test specific flags
 -------------------

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -199,7 +199,7 @@ class VerifyImageCache:
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
 
         overwrite_cache = (self.add_missing_images or self.reset_image_cache) and not self.reset_only_failed
-        if not Path(image_filename).isfiles() or overwrite_cache:
+        if not Path(image_filename).is_file() or overwrite_cache:
             if self.allow_unused_generated or overwrite_cache:
                 plotter.screenshot(image_filename)
             else:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -221,13 +221,13 @@ class VerifyImageCache:
         # "test_" to get the name for the image.
         image_name = test_name[5:] + ".png"
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
-        gen_image_filename = os.path.join(self.generated_image_dir, image_name)  # noqa: PTH118
+        gen_image_filename = None if self.generated_image_dir is None else os.path.join(self.generated_image_dir, image_name)  # noqa: PTH118
 
         if not os.path.isfile(image_filename) and not (self.allow_unused_generated or self.add_missing_images or self.reset_image_cache):  # noqa: PTH113
             # Raise error since the cached image does not exist and will not be added later
 
             # Save images as needed before error
-            if self.generated_image_dir is not None:
+            if gen_image_filename is not None:
                 plotter.screenshot(gen_image_filename)
             if self.failed_image_dir is not None:
                 self._save_failed_test_images("error", plotter, image_name)
@@ -239,7 +239,7 @@ class VerifyImageCache:
         if ((self.add_missing_images and not os.path.isfile(image_filename)) or self.reset_image_cache) and not self.reset_only_failed:  # noqa: PTH113
             plotter.screenshot(image_filename)
 
-        if self.generated_image_dir is not None:
+        if gen_image_filename is not None:
             plotter.screenshot(gen_image_filename)
 
         if not Path(image_filename).is_file() and self.allow_unused_generated:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -221,11 +221,17 @@ class VerifyImageCache:
         # "test_" to get the name for the image.
         image_name = test_name[5:] + ".png"
         image_filename = os.path.join(self.cache_dir, image_name)  # noqa: PTH118
+        gen_image_filename = os.path.join(self.generated_image_dir, image_name)  # noqa: PTH118
 
         if not os.path.isfile(image_filename) and not (self.allow_unused_generated or self.add_missing_images or self.reset_image_cache):  # noqa: PTH113
             # Raise error since the cached image does not exist and will not be added later
+
+            # Save images as needed before error
+            if self.generated_image_dir is not None:
+                plotter.screenshot(gen_image_filename)
             if self.failed_image_dir is not None:
                 self._save_failed_test_images("error", plotter, image_name)
+
             remove_plotter_close_callback()
             msg = f"{image_filename} does not exist in image cache"
             raise RegressionFileNotFound(msg)
@@ -234,7 +240,6 @@ class VerifyImageCache:
             plotter.screenshot(image_filename)
 
         if self.generated_image_dir is not None:
-            gen_image_filename = os.path.join(self.generated_image_dir, image_name)  # noqa: PTH118
             plotter.screenshot(gen_image_filename)
 
         if not Path(image_filename).is_file() and self.allow_unused_generated:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -15,11 +15,11 @@ def test_arguments(testdir) -> None:
         def test_args(verify_image_cache):
             assert verify_image_cache.reset_image_cache
             assert verify_image_cache.ignore_image_cache
-            assert verify_image_cache.fail_extra_image_cache
+            assert verify_image_cache.allow_unused_generated == False
 
         """
     )
-    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--fail_extra_image_cache")
+    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -51,7 +51,7 @@ def test_verify_image_cache(testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
     assert (testdir.tmpdir / "image_cache_dir").isdir()
@@ -74,7 +74,7 @@ def test_verify_image_cache_fail_regression(testdir) -> None:
        """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Ff]ailed*")
     result.stdout.fnmatch_lines("*Exceeded image regression error*")
     result.stdout.fnmatch_lines("*pytest_pyvista.pytest_pyvista.RegressionError:*")
@@ -98,7 +98,7 @@ def test_skip(testdir) -> None:
          """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -117,7 +117,7 @@ def test_image_cache_dir_commandline(testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache", "--image_cache_dir", "newdir")
+    result = testdir.runpytest("--image_cache_dir", "newdir")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -141,7 +141,7 @@ def test_image_cache_dir_ini(testdir) -> None:
         image_cache_dir = "newdir"
         """
     )
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -179,11 +179,11 @@ def test_high_variance_test(testdir) -> None:
             plotter.show()
         """
     )
-    result = testdir.runpytest("--fail_extra_image_cache", "test_file1.py")
+    result = testdir.runpytest("test_file1.py")
     result.stdout.fnmatch_lines("*[Ff]ailed*")
     result.stdout.fnmatch_lines("*Exceeded image regression error*")
 
-    result = testdir.runpytest("--fail_extra_image_cache", "test_file2.py")
+    result = testdir.runpytest("test_file2.py")
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -202,7 +202,7 @@ def test_generated_image_dir_commandline(testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache", "--generated_image_dir", "gen_dir")
+    result = testdir.runpytest("--generated_image_dir", "gen_dir")
     assert os.path.isdir(os.path.join(testdir.tmpdir, "gen_dir"))  # noqa: PTH112, PTH118
     assert os.path.isfile(os.path.join(testdir.tmpdir, "gen_dir", "imcache.png"))  # noqa: PTH113, PTH118
     result.stdout.fnmatch_lines("*[Pp]assed*")
@@ -228,7 +228,7 @@ def test_generated_image_dir_ini(testdir) -> None:
         generated_image_dir = "gen_dir"
         """
     )
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     assert os.path.isdir(os.path.join(testdir.tmpdir, "gen_dir"))  # noqa: PTH112, PTH118
     assert os.path.isfile(os.path.join(testdir.tmpdir, "gen_dir", "imcache.png"))  # noqa: PTH113, PTH118
     result.stdout.fnmatch_lines("*[Pp]assed*")
@@ -270,7 +270,7 @@ def test_reset_image_cache(testdir) -> None:
             plotter.show()
         """
     )
-    result = testdir.runpytest("--fail_extra_image_cache", "--reset_image_cache")
+    result = testdir.runpytest("--reset_image_cache")
     # file was overwritten
     assert not filecmp.cmp(filename, filename_original, shallow=False)
     # should pass even if image doesn't match
@@ -303,7 +303,7 @@ def test_cleanup(testdir) -> None:
        """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
@@ -346,6 +346,6 @@ def test_file_not_found(testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--fail_extra_image_cache")
+    result = testdir.runpytest()
     result.stdout.fnmatch_lines("*RegressionFileNotFound*")
     result.stdout.fnmatch_lines("*does not exist in image cache*")

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -83,8 +83,9 @@ def test_verify_image_cache_fail_regression(testdir) -> None:
     result.stdout.fnmatch_lines("*Exceeded image regression error of*")
 
 
+@pytest.mark.parametrize("use_generated_image_dir", [True, False])
 @pytest.mark.parametrize("allow_unused_generated", [True, False])
-def test_allow_unused_generated(testdir, allow_unused_generated) -> None:
+def test_allow_unused_generated(testdir, allow_unused_generated, use_generated_image_dir) -> None:
     """Test using `--allow_unused_generated` CLI option."""
     testdir.makepyfile(
         """
@@ -106,9 +107,15 @@ def test_allow_unused_generated(testdir, allow_unused_generated) -> None:
         args = []
         exit_code = pytest.ExitCode.TESTS_FAILED
         match = "*RegressionFileNotFound*"
+
+    if use_generated_image_dir:
+        args.extend(["--generated_image_dir", "gen_dir"])
+
     result = testdir.runpytest(*args)
     result.stdout.fnmatch_lines(match)
     assert result.ret == exit_code
+
+    assert (testdir.tmpdir / "gen_dir" / "imcache.png").isfile() == use_generated_image_dir
 
 
 def test_skip(testdir) -> None:


### PR DESCRIPTION
Follow-up to https://github.com/pyvista/pytest-pyvista/pull/92. Instead of simply renaming the argument, this PR also changes the default behavior so that an error is now raised by default if a generated image has no use.

I think this also resolves #36. The name `--allow_unused_generated` doesn't conflict with `--add_missing_images`, since enabling `--add_missing_images` is considered to be a usage of the images. This is documented in the README.

