### PR TITLE
Fix license field

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -79,6 +79,11 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
+      - name: Verify wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build && python -m twine check dist/*
+
       - name: Install pytest-pyvista with test dependencies
         run: |
           pip install .[tests] 'pyvista>=0.37'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -115,7 +115,11 @@ jobs:
     if: |
       github.event_name == 'push' &&
       contains(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
+    needs:
+      - doc
+      - Linux
+      - downstream
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Framework :: Pytest",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -19,7 +18,8 @@ classifiers = [
 ]
 dependencies = ["pytest>=3.5.0"]
 dynamic = ["description", "version"]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 name = "pytest_pyvista"
 python_requires = ">=3.9"
 readme = "README.rst"


### PR DESCRIPTION
### Problem

Release step failed in:
https://github.com/pyvista/pytest-pyvista/actions/runs/16119988259/job/45483046060

```
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - flit_core >=3.2,<4
* Getting build dependencies for sdist...
Unexpected names under [project]: python_requires
* Building sdist...
Unexpected names under [project]: python_requires
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - flit_core >=3.2,<4
* Getting build dependencies for wheel...
Unexpected names under [project]: python_requires
* Building wheel...
Unexpected names under [project]: python_requires
Successfully built pytest_pyvista-0.2.0.tar.gz and pytest_pyvista-0.2.0-py2.py3-none-any.whl
Checking dist/pytest_pyvista-0.2.0-py2.py3-none-any.whl: ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or
         malformed field 'license-file'
```

According to the release notes in `flit` v3.11 in:
https://flit.pypa.io/en/latest/history.html

We need should use the name of the license and we can also include the license file.

Docs are a bit light, but the [main flit documentation](https://flit.pypa.io/en/latest/flit_ini.html) seems to support that.


### Solution
- To prevent this occurring in the release, we're also going to check that the wheel is valid in the `Linux` unit testing step.
- Fix the license field
- Require documentation, unit testing, and downstream testing steps before release