### PR TITLE
Fix callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ tests = [
   "numpy<2.3",
   "pytest-cov==6.2.1",
   "pytest>=3.5.0",
-  "pytest_mock",
+  "pytest_mock<3.15",
 ]
 
 [project.entry-points."pytest11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["pytest>=3.5.0"]
+dependencies = ["pytest>=3.5.0", "pytest_mock"]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["pytest>=3.5.0", "pytest_mock"]
+dependencies = ["pytest>=3.5.0"]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -41,6 +41,7 @@ tests = [
   "numpy<2.3",
   "pytest-cov==6.2.1",
   "pytest>=3.5.0",
+  "pytest_mock",
 ]
 
 [project.entry-points."pytest11"]

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -7,17 +7,17 @@ from pathlib import Path
 import platform
 import shutil
 from typing import TYPE_CHECKING
+from typing import Callable
 from typing import Literal
 from typing import cast
 import warnings
 
 import pytest
 import pyvista
+from pyvista import Plotter
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
-
-    from pyvista import Plotter
 
 
 VISITED_CACHED_IMAGE_NAMES: set[str] = set()
@@ -408,8 +408,19 @@ def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
         setattr(item, f"rep_{rep.when}", rep)
 
 
+class _ChainedCallbacks:
+    def __init__(self, *funcs: Callable[[Plotter], None]) -> None:
+        """Chainable callbacks for pyvista.Plotter.show method."""
+        self.funcs = funcs
+
+    def __call__(self, plotter: Plotter) -> None:
+        """Call all input functions in chain for the given Plotter instance."""
+        for f in self.funcs:
+            f(plotter)
+
+
 @pytest.fixture
-def verify_image_cache(request, pytestconfig) -> Generator[VerifyImageCache, None, None]:  # noqa: ANN001
+def verify_image_cache(request, pytestconfig, monkeypatch: pytest.MonkeyPatch) -> Generator[VerifyImageCache, None, None]:  # noqa: ANN001
     """Check cached images against test images for PyVista."""
     # Set CMD options in class attributes
     VerifyImageCache.reset_image_cache = pytestconfig.getoption("reset_image_cache")
@@ -423,11 +434,18 @@ def verify_image_cache(request, pytestconfig) -> Generator[VerifyImageCache, Non
     failed_dir = _get_option_from_config_or_ini(pytestconfig, "failed_image_dir")
 
     verify_image_cache = VerifyImageCache(request.node.name, cache_dir, generated_image_dir=gen_dir, failed_image_dir=failed_dir)
-    pyvista.global_theme.before_close_callback = verify_image_cache
+
+    # Wrapping call to `Plotter.show` to inject the image cache callback
+    def func_show(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        key = "before_close_callback"
+        kwargs[key] = _ChainedCallbacks(kwargs.get(key, lambda *a: None), verify_image_cache)  # noqa: ARG005
+
+        old_show(*args, **kwargs)
+
+    old_show = Plotter.show
+    monkeypatch.setattr(Plotter, "show", func_show)
 
     yield verify_image_cache
-
-    pyvista.global_theme.before_close_callback = None
 
     # Check if the fixture was not used
     # Value from fixture takes precedence over value set by CLI

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -445,7 +445,7 @@ def verify_image_cache(request, pytestconfig, monkeypatch: pytest.MonkeyPatch) -
 
         kwargs[key] = _ChainedCallbacks(user_callback, verify_image_cache)
 
-        old_show(*args, **kwargs)
+        return old_show(*args, **kwargs)
 
     old_show = Plotter.show
     monkeypatch.setattr(Plotter, "show", func_show)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -438,7 +438,12 @@ def verify_image_cache(request, pytestconfig, monkeypatch: pytest.MonkeyPatch) -
     # Wrapping call to `Plotter.show` to inject the image cache callback
     def func_show(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
         key = "before_close_callback"
-        kwargs[key] = _ChainedCallbacks(kwargs.get(key, lambda *a: None), verify_image_cache)  # noqa: ARG005
+        user_callback = kwargs.get(key, lambda *a: ...)  # noqa: ARG005
+
+        if user_callback is None:  # special case encountered when using the `plot` property of pyvista objects
+            user_callback = lambda *a: ...  # noqa: ARG005, E731
+
+        kwargs[key] = _ChainedCallbacks(user_callback, verify_image_cache)
 
         old_show(*args, **kwargs)
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -70,20 +70,30 @@ def file_has_changed(filepath: str, original_contents_path: str | None = None, o
     return content_changed or replaced
 
 
-def test_verify_image_cache(testdir) -> None:
+@pytest.mark.parametrize("plot_property", [True, False])
+def test_verify_image_cache(testdir, plot_property: bool) -> None:  # noqa: FBT001
     """Test regular usage of the `verify_image_cache` fixture."""
     make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
-        """
-        import pyvista as pv
-        pv.OFF_SCREEN = True
-        def test_imcache(verify_image_cache):
-            sphere = pv.Sphere()
-            plotter = pv.Plotter()
-            plotter.add_mesh(sphere, color="red")
-            plotter.show()
-        """
-    )
+
+    if not plot_property:
+        pyfile = """
+            import pyvista as pv
+            pv.OFF_SCREEN = True
+            def test_imcache(verify_image_cache):
+                sphere = pv.Sphere()
+                plotter = pv.Plotter()
+                plotter.add_mesh(sphere, color="red")
+                plotter.show()
+            """
+    else:
+        pyfile = """
+            import pyvista as pv
+            pv.OFF_SCREEN = True
+            def test_imcache(verify_image_cache):
+                pv.Sphere().plot(color="red")
+            """
+
+    testdir.makepyfile(pyfile)
 
     result = testdir.runpytest()
     result.stdout.fnmatch_lines("*[Pp]assed*")


### PR DESCRIPTION
The `verify_image_cache` object is not called when a `before_close_callback` is already injected in `Plotter.show()`.

```python
import pyvista as pv

pv.OFF_SCREEN = True

def test_imcache(verify_image_cache, mocker):
    sphere = pv.Sphere()
    plotter = pv.Plotter()
    plotter.add_mesh(sphere, color="red")
    plotter.show(before_close_callback=(m := mocker.MagicMock()))

    m.assert_called_once_with(plotter)
```
```python
E               Failed: Fixture `verify_image_cache` is used but no images were generated.
E               Did you forget to call `show` or `plot`, or set `verify_image_cache.allow_useless_fixture=True`?.
```

This PR fixes it by fully wrapping the call to `Plotter.show`, injecting the `verify_image_cache` object on-the-fly after the user callback.
It induces that `pv.global_theme.before_close_callback` property is not modified.