### PR TITLE
Use pytester instead testdir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["pytest>=3.5.0"]
+dependencies = ["pytest>=6.2.0"]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -40,7 +40,7 @@ tests = [
   "coverage==7.9.1",
   "numpy<2.3",
   "pytest-cov==6.2.1",
-  "pytest>=3.5.0",
+  "pytest>=6.2.0",
 ]
 
 [project.entry-points."pytest11"]

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -14,7 +14,7 @@ import pyvista as pv
 pv.OFF_SCREEN = True
 
 
-def test_arguments(testdir) -> None:
+def test_arguments(testdir: pytest.Testdir) -> None:
     """Test pytest arguments."""
     testdir.makepyfile(
         """
@@ -70,7 +70,7 @@ def file_has_changed(filepath: str, original_contents_path: str | None = None, o
     return content_changed or replaced
 
 
-def test_verify_image_cache(testdir) -> None:
+def test_verify_image_cache(testdir: pytest.Testdir) -> None:
     """Test regular usage of the `verify_image_cache` fixture."""
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
@@ -93,7 +93,7 @@ def test_verify_image_cache(testdir) -> None:
     assert not (testdir.tmpdir / "failed_image_dir").isdir()
 
 
-def test_verify_image_cache_fail_regression(testdir) -> None:
+def test_verify_image_cache_fail_regression(testdir: pytest.Testdir) -> None:
     """Test regression of the `verify_image_cache` fixture."""
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
@@ -118,7 +118,7 @@ def test_verify_image_cache_fail_regression(testdir) -> None:
 
 @pytest.mark.parametrize("use_generated_image_dir", [True, False])
 @pytest.mark.parametrize("allow_unused_generated", [True, False])
-def test_allow_unused_generated(testdir, allow_unused_generated, use_generated_image_dir) -> None:
+def test_allow_unused_generated(testdir: pytest.Testdir, allow_unused_generated, use_generated_image_dir) -> None:
     """Test using `--allow_unused_generated` CLI option."""
     testdir.makepyfile(
         """
@@ -153,7 +153,7 @@ def test_allow_unused_generated(testdir, allow_unused_generated, use_generated_i
 
 @pytest.mark.parametrize("mock_platform_system", ["Darwin", None])
 @pytest.mark.parametrize("skip_type", ["skip", "ignore_image_cache", "macos_skip_image_cache"])
-def test_skip(testdir, skip_type: str, mock_platform_system: str) -> None:
+def test_skip(testdir: pytest.Testdir, skip_type: str, mock_platform_system: str) -> None:
     """Test all skip flags of `verify_image_cache`."""
     if mock_platform_system:
         # Simulate test for macOS
@@ -164,7 +164,7 @@ def test_skip(testdir, skip_type: str, mock_platform_system: str) -> None:
         _run_skip_test(testdir, skip_type)
 
 
-def _run_skip_test(testdir, skip_type: str) -> None:
+def _run_skip_test(testdir: pytest.Testdir, skip_type: str) -> None:
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
         f"""
@@ -186,7 +186,7 @@ def _run_skip_test(testdir, skip_type: str) -> None:
     result.stdout.fnmatch_lines(match)
 
 
-def test_image_cache_dir_commandline(testdir) -> None:
+def test_image_cache_dir_commandline(testdir: pytest.Testdir) -> None:
     """Test setting image_cache_dir via CLI option."""
     make_cached_images(testdir.tmpdir, "newdir")
     testdir.makepyfile(
@@ -205,7 +205,7 @@ def test_image_cache_dir_commandline(testdir) -> None:
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
-def test_image_cache_dir_ini(testdir) -> None:
+def test_image_cache_dir_ini(testdir: pytest.Testdir) -> None:
     """Test setting image_cache_dir via config."""
     make_cached_images(testdir.tmpdir, "newdir")
     testdir.makepyfile(
@@ -229,7 +229,7 @@ def test_image_cache_dir_ini(testdir) -> None:
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
-def test_high_variance_test(testdir) -> None:
+def test_high_variance_test(testdir: pytest.Testdir) -> None:
     """Test `skip` flag of `verify_image_cache`."""
     make_cached_images(testdir.tmpdir)
     make_cached_images(testdir.tmpdir, name="imcache_var.png")
@@ -271,7 +271,7 @@ def test_high_variance_test(testdir) -> None:
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
-def test_generated_image_dir_commandline(testdir) -> None:
+def test_generated_image_dir_commandline(testdir: pytest.Testdir) -> None:
     """Test setting generated_image_dir via CLI option."""
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
@@ -292,7 +292,7 @@ def test_generated_image_dir_commandline(testdir) -> None:
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
-def test_generated_image_dir_ini(testdir) -> None:
+def test_generated_image_dir_ini(testdir: pytest.Testdir) -> None:
     """Test setting generated_image_dir via config."""
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
@@ -321,7 +321,7 @@ def test_generated_image_dir_ini(testdir) -> None:
 @pytest.mark.parametrize("reset_only_failed", [True, False])
 @pytest.mark.parametrize("force_regression_error", [True, False])
 @pytest.mark.parametrize("add_second_test", [True, False])
-def test_add_missing_images_commandline(tmp_path, testdir, reset_only_failed, force_regression_error, add_second_test) -> None:
+def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset_only_failed, force_regression_error, add_second_test) -> None:
     """Test setting add_missing_images via CLI option."""
     if force_regression_error:
         # Make a cached image (which has a red sphere) but specify a blue sphere in the test file
@@ -387,7 +387,7 @@ def test_add_missing_images_commandline(tmp_path, testdir, reset_only_failed, fo
 
 @pytest.mark.parametrize("allow_unused_generated", [True, False])
 @pytest.mark.parametrize("make_cache", [True, False])
-def test_reset_image_cache(testdir, allow_unused_generated, make_cache) -> None:
+def test_reset_image_cache(testdir: pytest.Testdir, allow_unused_generated, make_cache) -> None:
     """Test reset_image_cache  via CLI option."""
     dirname = "image_cache_dir"
     test_image_name = "imcache.png"
@@ -421,7 +421,7 @@ def test_reset_image_cache(testdir, allow_unused_generated, make_cache) -> None:
     result.stdout.fnmatch_lines("*[Pp]assed*")
 
 
-def test_cleanup(testdir) -> None:
+def test_cleanup(testdir: pytest.Testdir) -> None:
     """Test cleanup of the `verify_image_cache` fixture."""
     make_cached_images(testdir.tmpdir)
     testdir.makepyfile(
@@ -453,7 +453,7 @@ def test_cleanup(testdir) -> None:
 
 @pytest.mark.parametrize("add_missing_images", [True, False])
 @pytest.mark.parametrize("reset_image_cache", [True, False])
-def test_reset_only_failed(testdir, reset_image_cache, add_missing_images) -> None:
+def test_reset_only_failed(testdir: pytest.Testdir, reset_image_cache, add_missing_images) -> None:
     """Test usage of the `reset_only_failed` flag."""
     filename = make_cached_images(testdir.tmpdir)
     filename_original = make_cached_images(testdir.tmpdir, name="original.png")
@@ -484,7 +484,7 @@ def test_reset_only_failed(testdir, reset_image_cache, add_missing_images) -> No
     assert not filecmp.cmp(filename, filename_original, shallow=False)
 
 
-def test_file_not_found(testdir) -> None:
+def test_file_not_found(testdir: pytest.Testdir) -> None:
     """Test RegressionFileNotFoundError is correctly raised."""
     testdir.makepyfile(
         """
@@ -504,7 +504,7 @@ def test_file_not_found(testdir) -> None:
 
 
 @pytest.mark.parametrize(("outcome", "make_cache"), [("error", False), ("error", True), ("warning", True), ("success", True)])
-def test_failed_image_dir(testdir, outcome, make_cache) -> None:
+def test_failed_image_dir(testdir: pytest.Testdir, outcome, make_cache) -> None:
     """Test usage of the `failed_image_dir` option."""
     cached_image_name = "imcache.png"
     if make_cache:
@@ -568,7 +568,7 @@ def test_failed_image_dir(testdir, outcome, make_cache) -> None:
 @pytest.mark.parametrize("call_show", [True, False])
 @pytest.mark.parametrize("allow_useless_fixture_cli", [True, False])
 @pytest.mark.parametrize("allow_useless_fixture_attr", [True, False, None])
-def test_allow_useless_fixture(testdir, call_show, allow_useless_fixture_cli, allow_useless_fixture_attr, skip) -> None:
+def test_allow_useless_fixture(testdir: pytest.Testdir, call_show, allow_useless_fixture_cli, allow_useless_fixture_attr, skip) -> None:
     """Test error is raised if fixture is used but no images are generated."""
     if call_show:
         # Ensure there is a cached image to compare to the generated image
@@ -667,7 +667,7 @@ def _unused_cache_lines(image_name: str) -> list[str]:
         (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [*_unused_cache_lines("imcache.png")], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),
     ],
 )
-def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
+def test_disallow_unused_cache(testdir: pytest.Testdir, marker, skip_verify, color, stdout_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
     """Ensure unused cached images are detected correctly."""
     test_name = "foo"
     image_name = test_name + ".png"
@@ -700,7 +700,7 @@ def test_disallow_unused_cache(testdir, marker, skip_verify, color, stdout_lines
 
 @pytest.mark.parametrize("skip", [True, False])
 @pytest.mark.parametrize("args", ["--disallow_unused_cache", []])
-def test_disallow_unused_cache_skip_multiple_images(testdir, skip, args) -> None:
+def test_disallow_unused_cache_skip_multiple_images(testdir: pytest.Testdir, skip, args) -> None:
     """Test skips when there are multiple calls to show() in a test."""
     make_cached_images(testdir.tmpdir, name="imcache.png")
     make_cached_images(testdir.tmpdir, name="imcache_1.png")
@@ -731,7 +731,7 @@ def test_disallow_unused_cache_skip_multiple_images(testdir, skip, args) -> None
 
 
 @pytest.mark.parametrize("disallow_unused_cache", [True, False])
-def test_disallow_unused_cache_name_mismatch(testdir, disallow_unused_cache) -> None:
+def test_disallow_unused_cache_name_mismatch(testdir: pytest.Testdir, disallow_unused_cache) -> None:
     """Test cached image doesn't match test name."""
     image_name = "im_cache.png"
     make_cached_images(testdir.tmpdir, name=image_name)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -13,10 +13,12 @@ import pyvista as pv
 
 pv.OFF_SCREEN = True
 
+pytest_plugins = "pytester"
 
-def test_arguments(testdir: pytest.Testdir) -> None:
+
+def test_arguments(pytester: pytest.Pytester) -> None:
     """Test pytest arguments."""
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         def test_args(verify_image_cache):
             assert verify_image_cache.reset_image_cache
@@ -25,7 +27,7 @@ def test_arguments(testdir: pytest.Testdir) -> None:
 
         """
     )
-    result = testdir.runpytest("--reset_image_cache", "--ignore_image_cache", "--disallow_unused_cache")
+    result = pytester.runpytest("--reset_image_cache", "--ignore_image_cache", "--disallow_unused_cache")
     result.assert_outcomes(passed=1)
 
 
@@ -70,10 +72,10 @@ def file_has_changed(filepath: str, original_contents_path: str | None = None, o
     return content_changed or replaced
 
 
-def test_verify_image_cache(testdir: pytest.Testdir) -> None:
+def test_verify_image_cache(pytester: pytest.Pytester) -> None:
     """Test regular usage of the `verify_image_cache` fixture."""
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -85,18 +87,18 @@ def test_verify_image_cache(testdir: pytest.Testdir) -> None:
         """
     )
 
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
-    assert (testdir.tmpdir / "image_cache_dir").isdir()
-    assert not (testdir.tmpdir / "generated_image_dir").isdir()
-    assert not (testdir.tmpdir / "failed_image_dir").isdir()
+    assert (pytester.path / "image_cache_dir").is_dir()
+    assert not (pytester.path / "generated_image_dir").is_dir()
+    assert not (pytester.path / "failed_image_dir").is_dir()
 
 
-def test_verify_image_cache_fail_regression(testdir: pytest.Testdir) -> None:
+def test_verify_image_cache_fail_regression(pytester: pytest.Pytester) -> None:
     """Test regression of the `verify_image_cache` fixture."""
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         """
        import pytest
        import pyvista as pv
@@ -109,7 +111,7 @@ def test_verify_image_cache_fail_regression(testdir: pytest.Testdir) -> None:
        """
     )
 
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines("*Exceeded image regression error*")
     result.stdout.fnmatch_lines("*pytest_pyvista.pytest_pyvista.RegressionError:*")
@@ -118,9 +120,9 @@ def test_verify_image_cache_fail_regression(testdir: pytest.Testdir) -> None:
 
 @pytest.mark.parametrize("use_generated_image_dir", [True, False])
 @pytest.mark.parametrize("allow_unused_generated", [True, False])
-def test_allow_unused_generated(testdir: pytest.Testdir, allow_unused_generated, use_generated_image_dir) -> None:
+def test_allow_unused_generated(pytester: pytest.Pytester, allow_unused_generated, use_generated_image_dir) -> None:
     """Test using `--allow_unused_generated` CLI option."""
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
        import pytest
        import pyvista as pv
@@ -144,29 +146,29 @@ def test_allow_unused_generated(testdir: pytest.Testdir, allow_unused_generated,
     if use_generated_image_dir:
         args.extend(["--generated_image_dir", "gen_dir"])
 
-    result = testdir.runpytest(*args)
+    result = pytester.runpytest(*args)
     result.stdout.fnmatch_lines(match)
     assert result.ret == exit_code
 
-    assert (testdir.tmpdir / "gen_dir" / "imcache.png").isfile() == use_generated_image_dir
+    assert (pytester.path / "gen_dir" / "imcache.png").is_file() == use_generated_image_dir
 
 
 @pytest.mark.parametrize("mock_platform_system", ["Darwin", None])
 @pytest.mark.parametrize("skip_type", ["skip", "ignore_image_cache", "macos_skip_image_cache"])
-def test_skip(testdir: pytest.Testdir, skip_type: str, mock_platform_system: str) -> None:
+def test_skip(pytester: pytest.Pytester, skip_type: str, mock_platform_system: str) -> None:
     """Test all skip flags of `verify_image_cache`."""
     if mock_platform_system:
         # Simulate test for macOS
         patcher = mock.patch("platform.system", return_value=mock_platform_system)
         with patcher:
-            _run_skip_test(testdir, skip_type)
+            _run_skip_test(pytester, skip_type)
     else:
-        _run_skip_test(testdir, skip_type)
+        _run_skip_test(pytester, skip_type)
 
 
-def _run_skip_test(testdir: pytest.Testdir, skip_type: str) -> None:
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+def _run_skip_test(pytester: pytest.Pytester, skip_type: str) -> None:
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         f"""
         import pytest
         import pyvista as pv
@@ -180,16 +182,16 @@ def _run_skip_test(testdir: pytest.Testdir, skip_type: str) -> None:
          """
     )
 
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     # Expect failure if verification is not skipped
     match = "*RegressionError*" if skip_type == "macos_skip_image_cache" and platform.system() != "Darwin" else "*[Pp]assed*"
     result.stdout.fnmatch_lines(match)
 
 
-def test_image_cache_dir_commandline(testdir: pytest.Testdir) -> None:
+def test_image_cache_dir_commandline(pytester: pytest.Pytester) -> None:
     """Test setting image_cache_dir via CLI option."""
-    make_cached_images(testdir.tmpdir, "newdir")
-    testdir.makepyfile(
+    make_cached_images(pytester.path, "newdir")
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -201,14 +203,14 @@ def test_image_cache_dir_commandline(testdir: pytest.Testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--image_cache_dir", "newdir")
+    result = pytester.runpytest("--image_cache_dir", "newdir")
     result.assert_outcomes(passed=1)
 
 
-def test_image_cache_dir_ini(testdir: pytest.Testdir) -> None:
+def test_image_cache_dir_ini(pytester: pytest.Pytester) -> None:
     """Test setting image_cache_dir via config."""
-    make_cached_images(testdir.tmpdir, "newdir")
-    testdir.makepyfile(
+    make_cached_images(pytester.path, "newdir")
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -219,23 +221,23 @@ def test_image_cache_dir_ini(testdir: pytest.Testdir) -> None:
             plotter.show()
         """
     )
-    testdir.makepyprojecttoml(
+    pytester.makepyprojecttoml(
         """
         [tool.pytest.ini_options]
         image_cache_dir = "newdir"
         """
     )
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
-def test_high_variance_test(testdir: pytest.Testdir) -> None:
+def test_high_variance_test(pytester: pytest.Pytester) -> None:
     """Test `skip` flag of `verify_image_cache`."""
-    make_cached_images(testdir.tmpdir)
-    make_cached_images(testdir.tmpdir, name="imcache_var.png")
+    make_cached_images(pytester.path)
+    make_cached_images(pytester.path, name="imcache_var.png")
 
     # First make sure test fails with image regression error
-    testdir.makepyfile(
+    pytester.makepyfile(
         test_file1="""
         import pytest
         import pyvista as pv
@@ -249,7 +251,7 @@ def test_high_variance_test(testdir: pytest.Testdir) -> None:
         """
     )
     # Next mark as a high_variance_test and check that it passes
-    testdir.makepyfile(
+    pytester.makepyfile(
         test_file2="""
         import pytest
         import pyvista as pv
@@ -263,18 +265,18 @@ def test_high_variance_test(testdir: pytest.Testdir) -> None:
             plotter.show()
         """
     )
-    result = testdir.runpytest("test_file1.py")
+    result = pytester.runpytest("test_file1.py")
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines("*Exceeded image regression error*")
 
-    result = testdir.runpytest("test_file2.py")
+    result = pytester.runpytest("test_file2.py")
     result.assert_outcomes(passed=1)
 
 
-def test_generated_image_dir_commandline(testdir: pytest.Testdir) -> None:
+def test_generated_image_dir_commandline(pytester: pytest.Pytester) -> None:
     """Test setting generated_image_dir via CLI option."""
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -286,16 +288,16 @@ def test_generated_image_dir_commandline(testdir: pytest.Testdir) -> None:
         """
     )
 
-    result = testdir.runpytest("--generated_image_dir", "gen_dir")
-    assert (testdir.tmpdir / "gen_dir").isdir()
-    assert (testdir.tmpdir / "gen_dir" / "imcache.png").isfile()
+    result = pytester.runpytest("--generated_image_dir", "gen_dir")
+    assert (pytester.path / "gen_dir").is_dir()
+    assert (pytester.path / "gen_dir" / "imcache.png").is_file()
     result.assert_outcomes(passed=1)
 
 
-def test_generated_image_dir_ini(testdir: pytest.Testdir) -> None:
+def test_generated_image_dir_ini(pytester: pytest.Pytester) -> None:
     """Test setting generated_image_dir via config."""
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -306,27 +308,27 @@ def test_generated_image_dir_ini(testdir: pytest.Testdir) -> None:
             plotter.show()
         """
     )
-    testdir.makepyprojecttoml(
+    pytester.makepyprojecttoml(
         """
         [tool.pytest.ini_options]
         generated_image_dir = "gen_dir"
         """
     )
-    result = testdir.runpytest()
-    assert (testdir.tmpdir / "gen_dir").isdir()
-    assert (testdir.tmpdir / "gen_dir" / "imcache.png").isfile()
+    result = pytester.runpytest()
+    assert (pytester.path / "gen_dir").is_dir()
+    assert (pytester.path / "gen_dir" / "imcache.png").is_file()
     result.assert_outcomes(passed=1)
 
 
 @pytest.mark.parametrize("reset_only_failed", [True, False])
 @pytest.mark.parametrize("force_regression_error", [True, False])
 @pytest.mark.parametrize("add_second_test", [True, False])
-def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset_only_failed, force_regression_error, add_second_test) -> None:
+def test_add_missing_images_commandline(tmp_path, pytester: pytest.Pytester, reset_only_failed, force_regression_error, add_second_test) -> None:
     """Test setting add_missing_images via CLI option."""
     if force_regression_error:
         # Make a cached image (which has a red sphere) but specify a blue sphere in the test file
         # to generate a regression failure
-        make_cached_images(testdir.tmpdir)
+        make_cached_images(pytester.path)
         color = "blue"
     else:
         color = "red"
@@ -334,7 +336,7 @@ def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset
     if add_second_test:
         second_color = "lime"
         assert second_color != color
-        always_passes_filename = make_cached_images(testdir.tmpdir, name="always_passes.png", color=second_color)
+        always_passes_filename = make_cached_images(pytester.path, name="always_passes.png", color=second_color)
         always_passes_ground_truth = make_cached_images(tmp_path, name="always_passes.png", color=second_color)
         always_passes_inode = get_path_inode(always_passes_filename)
         second_test = f"""
@@ -349,7 +351,7 @@ def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset
     else:
         second_test = ""
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         f"""
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -364,15 +366,15 @@ def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset
     args = ["--add_missing_images"]
     if reset_only_failed:
         args.append("--reset_only_failed")
-    result = testdir.runpytest(*args)
+    result = pytester.runpytest(*args)
 
     if force_regression_error and not reset_only_failed:
         result.stdout.fnmatch_lines("*RegressionError*")
         assert result.ret == pytest.ExitCode.TESTS_FAILED
     else:
-        expected_file = testdir.tmpdir / "image_cache_dir" / "imcache.png"
-        assert expected_file.isfile()
-        result.assert_outcomes(passed=2)
+        expected_file = pytester.path / "image_cache_dir" / "imcache.png"
+        assert expected_file.is_file()
+        result.assert_outcomes(passed=2 if add_second_test else 1)
         assert result.ret == pytest.ExitCode.OK
 
         # Make sure the final image in the cache matches the generated test image
@@ -387,20 +389,20 @@ def test_add_missing_images_commandline(tmp_path, testdir: pytest.Testdir, reset
 
 @pytest.mark.parametrize("allow_unused_generated", [True, False])
 @pytest.mark.parametrize("make_cache", [True, False])
-def test_reset_image_cache(testdir: pytest.Testdir, allow_unused_generated, make_cache) -> None:
+def test_reset_image_cache(pytester: pytest.Pytester, allow_unused_generated, make_cache) -> None:
     """Test reset_image_cache  via CLI option."""
     dirname = "image_cache_dir"
     test_image_name = "imcache.png"
-    filename_test = testdir.tmpdir / dirname / test_image_name
-    filename_original = make_cached_images(testdir.tmpdir, dirname, name="original.png")
+    filename_test = pytester.path / dirname / test_image_name
+    filename_original = make_cached_images(pytester.path, dirname, name="original.png")
     if make_cache:
-        filename = make_cached_images(testdir.tmpdir)
+        filename = make_cached_images(pytester.path)
         assert filecmp.cmp(filename, filename_original, shallow=False)
     else:
         filename = filename_test
-        assert not filename_test.isfile()
+        assert not filename_test.is_file()
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -414,17 +416,17 @@ def test_reset_image_cache(testdir: pytest.Testdir, allow_unused_generated, make
     args = ["--reset_image_cache"]
     if allow_unused_generated:
         args.append("--allow_unused_generated")
-    result = testdir.runpytest(*args)
+    result = pytester.runpytest(*args)
     # file was created or overwritten
     assert not filecmp.cmp(filename, filename_original, shallow=False)
     # should pass even if image doesn't match
     result.assert_outcomes(passed=1)
 
 
-def test_cleanup(testdir: pytest.Testdir) -> None:
+def test_cleanup(pytester: pytest.Pytester) -> None:
     """Test cleanup of the `verify_image_cache` fixture."""
-    make_cached_images(testdir.tmpdir)
-    testdir.makepyfile(
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
         """
        import pytest
        import pyvista as pv
@@ -447,19 +449,19 @@ def test_cleanup(testdir: pytest.Testdir) -> None:
        """
     )
 
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
 @pytest.mark.parametrize("add_missing_images", [True, False])
 @pytest.mark.parametrize("reset_image_cache", [True, False])
-def test_reset_only_failed(testdir: pytest.Testdir, reset_image_cache, add_missing_images) -> None:
+def test_reset_only_failed(pytester: pytest.Pytester, reset_image_cache, add_missing_images) -> None:
     """Test usage of the `reset_only_failed` flag."""
-    filename = make_cached_images(testdir.tmpdir)
-    filename_original = make_cached_images(testdir.tmpdir, name="original.png")
+    filename = make_cached_images(pytester.path)
+    filename_original = make_cached_images(pytester.path, name="original.png")
     assert filecmp.cmp(filename, filename_original, shallow=False)
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -477,16 +479,16 @@ def test_reset_only_failed(testdir: pytest.Testdir, reset_image_cache, add_missi
     if reset_image_cache:
         args.append("--reset_image_cache")
 
-    result = testdir.runpytest(*args)
+    result = pytester.runpytest(*args)
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines("*This image will be reset in the cache.")
     # file was overwritten
     assert not filecmp.cmp(filename, filename_original, shallow=False)
 
 
-def test_file_not_found(testdir: pytest.Testdir) -> None:
+def test_file_not_found(pytester: pytest.Pytester) -> None:
     """Test RegressionFileNotFoundError is correctly raised."""
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -498,23 +500,23 @@ def test_file_not_found(testdir: pytest.Testdir) -> None:
         """
     )
 
-    result = testdir.runpytest()
+    result = pytester.runpytest()
     result.stdout.fnmatch_lines("*RegressionFileNotFoundError*")
     result.stdout.fnmatch_lines("*does not exist in image cache*")
 
 
 @pytest.mark.parametrize(("outcome", "make_cache"), [("error", False), ("error", True), ("warning", True), ("success", True)])
-def test_failed_image_dir(testdir: pytest.Testdir, outcome, make_cache) -> None:
+def test_failed_image_dir(pytester: pytest.Pytester, outcome, make_cache) -> None:
     """Test usage of the `failed_image_dir` option."""
     cached_image_name = "imcache.png"
     if make_cache:
-        make_cached_images(testdir.tmpdir)
+        make_cached_images(pytester.path)
 
     red = [255, 0, 0]
     almost_red = [250, 0, 0]
     definitely_not_red = [0, 0, 0]
     color = definitely_not_red if outcome == "error" else almost_red if outcome == "warning" else red
-    testdir.makepyfile(
+    pytester.makepyfile(
         f"""
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -526,11 +528,11 @@ def test_failed_image_dir(testdir: pytest.Testdir, outcome, make_cache) -> None:
         """
     )
     dirname = "failed_image_dir"
-    result = testdir.runpytest("--failed_image_dir", dirname)
+    result = pytester.runpytest("--failed_image_dir", dirname)
 
-    failed_image_dir_path = testdir.tmpdir / dirname
+    failed_image_dir_path = pytester.path / dirname
     if outcome == "success":
-        assert not failed_image_dir_path.isdir()
+        assert not failed_image_dir_path.is_dir()
     else:
         result.stdout.fnmatch_lines("*UserWarning: pyvista test failed image dir: failed_image_dir does not yet exist.  Creating dir.")
         if make_cache:
@@ -545,38 +547,38 @@ def test_failed_image_dir(testdir: pytest.Testdir, outcome, make_cache) -> None:
             expected_subdir = "warnings"
             not_expected_subdir = "errors"
 
-        assert failed_image_dir_path.isdir()
+        assert failed_image_dir_path.is_dir()
 
         # Test that dir with failed images is only created as needed
-        assert (failed_image_dir_path / expected_subdir).isdir()
-        assert not (failed_image_dir_path / not_expected_subdir).isdir()
+        assert (failed_image_dir_path / expected_subdir).is_dir()
+        assert not (failed_image_dir_path / not_expected_subdir).is_dir()
 
         from_test_dir = failed_image_dir_path / expected_subdir / "from_test"
-        assert from_test_dir.isdir()
-        assert (from_test_dir / cached_image_name).isfile()
+        assert from_test_dir.is_dir()
+        assert (from_test_dir / cached_image_name).is_file()
 
         from_cache_dir = failed_image_dir_path / expected_subdir / "from_cache"
         if make_cache:
-            assert from_cache_dir.isdir()
-            assert (from_cache_dir / cached_image_name).isfile()
+            assert from_cache_dir.is_dir()
+            assert (from_cache_dir / cached_image_name).is_file()
         else:
-            assert not from_cache_dir.isdir()
-            assert not (from_cache_dir / cached_image_name).isfile()
+            assert not from_cache_dir.is_dir()
+            assert not (from_cache_dir / cached_image_name).is_file()
 
 
 @pytest.mark.parametrize("skip", [True, False])
 @pytest.mark.parametrize("call_show", [True, False])
 @pytest.mark.parametrize("allow_useless_fixture_cli", [True, False])
 @pytest.mark.parametrize("allow_useless_fixture_attr", [True, False, None])
-def test_allow_useless_fixture(testdir: pytest.Testdir, call_show, allow_useless_fixture_cli, allow_useless_fixture_attr, skip) -> None:
+def test_allow_useless_fixture(pytester: pytest.Pytester, call_show, allow_useless_fixture_cli, allow_useless_fixture_attr, skip) -> None:
     """Test error is raised if fixture is used but no images are generated."""
     if call_show:
         # Ensure there is a cached image to compare to the generated image
-        make_cached_images(testdir.tmpdir)
+        make_cached_images(pytester.path)
 
     allow_attr = "" if allow_useless_fixture_attr is None else f"verify_image_cache.allow_useless_fixture = {allow_useless_fixture_attr}"
     skip_attr = f"verify_image_cache.skip = {skip}"
-    testdir.makepyfile(
+    pytester.makepyfile(
         f"""
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -590,7 +592,7 @@ def test_allow_useless_fixture(testdir: pytest.Testdir, call_show, allow_useless
         """
     )
 
-    result = testdir.runpytest("--allow_useless_fixture") if allow_useless_fixture_cli else testdir.runpytest()
+    result = pytester.runpytest("--allow_useless_fixture") if allow_useless_fixture_cli else pytester.runpytest()
 
     # Expect local attr to take precedence over CLI value
     allow_useless_fixture = allow_useless_fixture_attr if allow_useless_fixture_attr is not None else allow_useless_fixture_cli
@@ -667,17 +669,17 @@ def _unused_cache_lines(image_name: str) -> list[str]:
         (PytestMark.NONE, SkipVerify.NONE, MeshColor.FAIL, [*_unused_cache_lines("imcache.png")], pytest.ExitCode.TESTS_FAILED, HasUnusedCache.TRUE),
     ],
 )
-def test_disallow_unused_cache(testdir: pytest.Testdir, marker, skip_verify, color, stdout_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
+def test_disallow_unused_cache(pytester: pytest.Pytester, marker, skip_verify, color, stdout_lines, exit_code, has_unused_cache) -> None:  # noqa: PLR0913
     """Ensure unused cached images are detected correctly."""
     test_name = "foo"
     image_name = test_name + ".png"
     image_cache_dir = "image_cache_dir"
 
-    make_cached_images(testdir.tmpdir, image_cache_dir, image_name)
+    make_cached_images(pytester.path, image_cache_dir, image_name)
     if has_unused_cache:
-        make_cached_images(testdir.tmpdir)
+        make_cached_images(pytester.path)
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         f"""
         import pytest
         import pyvista as pv
@@ -692,7 +694,7 @@ def test_disallow_unused_cache(testdir: pytest.Testdir, marker, skip_verify, col
         """
     )
 
-    result = testdir.runpytest("--disallow_unused_cache")
+    result = pytester.runpytest("--disallow_unused_cache")
 
     assert result.ret == exit_code
     result.stdout.fnmatch_lines(stdout_lines)
@@ -700,13 +702,13 @@ def test_disallow_unused_cache(testdir: pytest.Testdir, marker, skip_verify, col
 
 @pytest.mark.parametrize("skip", [True, False])
 @pytest.mark.parametrize("args", ["--disallow_unused_cache", []])
-def test_disallow_unused_cache_skip_multiple_images(testdir: pytest.Testdir, skip, args) -> None:
+def test_disallow_unused_cache_skip_multiple_images(pytester: pytest.Pytester, skip, args) -> None:
     """Test skips when there are multiple calls to show() in a test."""
-    make_cached_images(testdir.tmpdir, name="imcache.png")
-    make_cached_images(testdir.tmpdir, name="imcache_1.png")
+    make_cached_images(pytester.path, name="imcache.png")
+    make_cached_images(pytester.path, name="imcache_1.png")
 
     marker = "@pytest.mark.skip" if skip else ""
-    testdir.makepyfile(
+    pytester.makepyfile(
         f"""
         import pytest
         import pyvista as pv
@@ -724,20 +726,20 @@ def test_disallow_unused_cache_skip_multiple_images(testdir: pytest.Testdir, ski
         """
     )
 
-    result = testdir.runpytest(args)
+    result = pytester.runpytest(args)
     expected = "*skipped*" if skip else "*[Pp]assed*"
     result.stdout.fnmatch_lines(expected)
     assert result.ret == pytest.ExitCode.OK
 
 
 @pytest.mark.parametrize("disallow_unused_cache", [True, False])
-def test_disallow_unused_cache_name_mismatch(testdir: pytest.Testdir, disallow_unused_cache) -> None:
+def test_disallow_unused_cache_name_mismatch(pytester: pytest.Pytester, disallow_unused_cache) -> None:
     """Test cached image doesn't match test name."""
     image_name = "im_cache.png"
-    make_cached_images(testdir.tmpdir, name=image_name)
-    make_cached_images(testdir.tmpdir)
+    make_cached_images(pytester.path, name=image_name)
+    make_cached_images(pytester.path)
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         import pyvista as pv
         pv.OFF_SCREEN = True
@@ -749,7 +751,7 @@ def test_disallow_unused_cache_name_mismatch(testdir: pytest.Testdir, disallow_u
         """
     )
     args = "--disallow_unused_cache" if disallow_unused_cache else []
-    result = testdir.runpytest(args)
+    result = pytester.runpytest(args)
     if disallow_unused_cache:
         result.stdout.fnmatch_lines([*_unused_cache_lines(image_name)])
         assert result.ret == pytest.ExitCode.TESTS_FAILED


### PR DESCRIPTION
According to `pytest` [documentation](https://docs.pytest.org/en/latest/reference/reference.html#std-fixture-testdir), the `testdir` fixture is to be replaced with the more recent `pytester` one.

In addition to that, `result.stdout.fnmatch_lines("*[Pp]assed*")` calls are replaced by `result.assert_outcomes(passed=1)` to explicitly count the number of test status. 