### PR TITLE
Use dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,4 @@ updates:
       actions:
         patterns:
           - "*"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Enable dependabot groups to avoid this madness:

<img width="1332" height="280" alt="sc003" src="https://github.com/user-attachments/assets/fd4ea6b9-abee-483d-b713-a47e343c5234" />
