### PR TITLE
Allow customizing env info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,6 +234,7 @@ in the beginning of your test function.
         # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
         info.os: bool = True  # Show/hide the os version (e.g. ubuntu, macOS)
+        info.machine: bool = True  # Show/hide the machine info (e.g. arm64)
         info.python: bool = True  # Show/hide the python version
         info.pyvista: bool = True  # Show/hide the pyvista version
         info.vtk: bool = True  # Show/hide the vtk version

--- a/README.rst
+++ b/README.rst
@@ -168,8 +168,8 @@ These are the flags you can use when calling ``pytest`` in the command line:
   option enabled, they are instead saved as
   ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has the format
   ``<system>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
-  This can be useful for providing context about how an image was generated. See
-  :ref:`Test specific flags` for customizing the info.
+  This can be useful for providing context about how an image was generated. See the
+  ``Test specific flags`` section for customizing the info.
 
 * ``--failed_image_dir <DIR>`` dumps copies of cached and generated test images when
   there is a warning or error raised. This directory is useful for reviewing test

--- a/README.rst
+++ b/README.rst
@@ -229,9 +229,8 @@ in the beginning of your test function.
 
     @pytest.fixture(autouse=True)
     def wrapped_verify_image_cache(verify_image_cache):
+        # Customize the environment info (NOTE: Default values are shown)
         info = verify_image_cache.env_info
-
-        # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
         info.os: bool = True  # Show/hide the os version (e.g. ubuntu, macOS, Windows)
         info.machine: bool = True  # Show/hide the machine info (e.g. arm64)
@@ -241,6 +240,9 @@ in the beginning of your test function.
         info.vtk: bool = True  # Show/hide the vtk version
         info.ci: bool = True  # Show/hide if generated in CI
         info.suffix: str = ""  # Add a custom suffix
+
+        # Alternatively, set a custom string
+        verify_image_cache.env_info = 'my_custom_string'
 
         return verify_image_cache
 

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ in the beginning of your test function.
 
         # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
-        info.os: bool = True  # Show/hide the os (e.g. ubuntu, macOS)
+        info.os: bool = True  # Show/hide the os version (e.g. ubuntu, macOS)
         info.python: bool = True  # Show/hide the python version
         info.pyvista: bool = True  # Show/hide the pyvista version
         info.vtk: bool = True  # Show/hide the vtk version

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ in the beginning of your test function.
 
         # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
-        info.system: bool = True  # Show/hide the system platform (e.g. Linux)
+        info.os: bool = True  # Show/hide the os (e.g. ubuntu, macOS)
         info.python: bool = True  # Show/hide the python version
         info.pyvista: bool = True  # Show/hide the pyvista version
         info.vtk: bool = True  # Show/hide the vtk version

--- a/README.rst
+++ b/README.rst
@@ -222,8 +222,8 @@ in the beginning of your test function.
   flag takes precedence over the global flag by the same name (see above).
 
 * ``env_info``: Dataclass for controlling the environment info used to name the generated
-  test image when the ``--generate_dirs`` option is used. The info can be test-specific or
-  can be modified globally by wrapping the ``verify_image_cache`` fixture, e.g.:
+  test image(s) when the ``--generate_dirs`` option is used. The info can be test-specific
+  or can be modified globally by wrapping the ``verify_image_cache`` fixture, e.g.:
 
   .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
   generated images are saved as ``generated_image_dir/<test_name>.png``; with this
   option enabled, they are instead saved as
   ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has the format
-  ``<system>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
+  ``<os>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
   This can be useful for providing context about how an image was generated. See the
   ``Test specific flags`` section for customizing the info.
 

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
   generated images are saved as ``generated_image_dir/<test_name>.png``; with this
   option enabled, they are instead saved as
   ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has the format
-  ``<os>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
+  ``<os-version>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
   This can be useful for providing context about how an image was generated. See the
   ``Test specific flags`` section for customizing the info.
 

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
   generated images are saved as ``generated_image_dir/<test_name>.png``; with this
   option enabled, they are instead saved as
   ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has the format
-  ``<os-version>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
+  ``<os-version>_<machine>_<gpu-vendor>_<python-version>_<pyvista-version>_<vtk-version>_<using-ci>``.
   This can be useful for providing context about how an image was generated. See the
   ``Test specific flags`` section for customizing the info.
 
@@ -233,13 +233,13 @@ in the beginning of your test function.
 
         # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
-        info.os: bool = True  # Show/hide the os version (e.g. ubuntu, macOS)
+        info.os: bool = True  # Show/hide the os version (e.g. ubuntu, macOS, Windows)
         info.machine: bool = True  # Show/hide the machine info (e.g. arm64)
+        info.gpu: bool = True  # Show/hide the gpu vendor (e.g. NVIDIA)
         info.python: bool = True  # Show/hide the python version
         info.pyvista: bool = True  # Show/hide the pyvista version
         info.vtk: bool = True  # Show/hide the vtk version
-        info.gpu: bool = True  # Show/hide the gpu vendor (e.g. NVIDIA)
-        info.host: bool = True  # Show/hide the host (e.g self-hosted, github-hosted)
+        info.ci: bool = True  # Show/hide if generated in CI
         info.suffix: str = ""  # Add a custom suffix
 
         return verify_image_cache

--- a/README.rst
+++ b/README.rst
@@ -166,9 +166,10 @@ These are the flags you can use when calling ``pytest`` in the command line:
   instead of saving them directly to the ``generated_image_dir``. Without this option,
   generated images are saved as ``generated_image_dir/<test_name>.png``; with this
   option enabled, they are instead saved as
-  ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has
-  the format ``<system>_<python-version>_<pyvista-version>_<vtk-version>``. This can
-  be useful for providing context about how an image was generated.
+  ``<generated_image_dir>/<test_name>/<image_name>.png``, where the image name has the format
+  ``<system>_<python-version>_<pyvista-version>_<vtk-version>_<gpu-vendor>_<host>``.
+  This can be useful for providing context about how an image was generated. See
+  :ref:`Test specific flags` for customizing the info.
 
 * ``--failed_image_dir <DIR>`` dumps copies of cached and generated test images when
   there is a warning or error raised. This directory is useful for reviewing test
@@ -219,6 +220,28 @@ in the beginning of your test function.
 * ``allow_useless_fixture``: Set this flag to ``True`` to prevent test failure when the
   ``verify_image_cache`` fixture is used but no images are generated. The value of this
   flag takes precedence over the global flag by the same name (see above).
+
+* ``env_info``: Dataclass for controlling the environment info used to name the generated
+  test image when the ``--generate_dirs`` option is used. The info can be test-specific or
+  can be modified globally by wrapping the ``verify_image_cache`` fixture, e.g.:
+
+  .. code-block:: python
+
+    @pytest.fixture(autouse=True)
+    def wrapped_verify_image_cache(verify_image_cache):
+        info = verify_image_cache.env_info
+
+        # NOTE: Default values are show
+        info.prefix: str = ""  # Add a custom prefix
+        info.system: bool = True  # Show/hide the system platform
+        info.python: bool = True  # Show/hide the python version
+        info.pyvista: bool = True  # Show/hide the pyvista version
+        info.vtk: bool = True  # Show/hide the vtk version
+        info.gpu: bool = True  # Show/hide the gpu vendor
+        info.host: bool = True  # Show/hide the host (e.g self-hosted, github-hosted)
+        info.suffix: str = ""  # Add a custom suffix
+
+        return verify_image_cache
 
 Documentation image tests
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -231,13 +231,13 @@ in the beginning of your test function.
     def wrapped_verify_image_cache(verify_image_cache):
         info = verify_image_cache.env_info
 
-        # NOTE: Default values are show
+        # NOTE: Default values are shown
         info.prefix: str = ""  # Add a custom prefix
-        info.system: bool = True  # Show/hide the system platform
+        info.system: bool = True  # Show/hide the system platform (e.g. Linux)
         info.python: bool = True  # Show/hide the python version
         info.pyvista: bool = True  # Show/hide the pyvista version
         info.vtk: bool = True  # Show/hide the vtk version
-        info.gpu: bool = True  # Show/hide the gpu vendor
+        info.gpu: bool = True  # Show/hide the gpu vendor (e.g. NVIDIA)
         info.host: bool = True  # Show/hide the host (e.g self-hosted, github-hosted)
         info.suffix: str = ""  # Add a custom suffix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["distro; sys_platform == 'linux'", "pytest>=6.2.0"]
+dependencies = ["pytest>=6.2.0"]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["pytest>=6.2.0"]
+dependencies = ["distro; sys_platform == 'linux'", "pytest>=6.2.0"]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:  # pragma: no cover
 VISITED_CACHED_IMAGE_NAMES: set[str] = set()
 SKIPPED_CACHED_IMAGE_NAMES: set[str] = set()
 
+try:
+    _GPU_VENDOR = pyvista.GPUInfo().vendor
+except Exception:  # noqa: BLE001 # pragma: no cover
+    _GPU_VENDOR = "UNKNOWN"
+
 
 @dataclass
 class _EnvInfo:
@@ -37,6 +42,7 @@ class _EnvInfo:
     python: bool = True
     pyvista: bool = True
     vtk: bool = True
+    gpu: bool = True
     runner: bool = True
     suffix: str = ""
 
@@ -45,8 +51,19 @@ class _EnvInfo:
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
-        runner = os.environ.get("RUNNER_ENVIRONMENT", "local") if self.runner else ""
-        values = [f"{self.prefix}", f"{system_version}", f"{python_version}", f"{pyvista_version}", f"{vtk_version}", f"{runner}", f"{self.suffix}"]
+        gpu = f"gpu-{_GPU_VENDOR}" if self.gpu else ""
+        runner = os.environ.get("RUNNER_ENVIRONMENT", "local-hosted") if self.runner else ""
+
+        values = [
+            f"{self.prefix}",
+            f"{system_version}",
+            f"{python_version}",
+            f"{pyvista_version}",
+            f"{vtk_version}",
+            f"{gpu}",
+            f"{runner}",
+            f"{self.suffix}",
+        ]
         return "_".join(val for val in values if val)
 
     @staticmethod

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -70,14 +70,14 @@ class _EnvInfo:
         return "macOS" if system == "Darwin" else system
 
     @staticmethod
-    def _gpu_vendor() -> str:  # pragma: no cover
+    def _gpu_vendor() -> str:
         # Get cached value
         if _GPU_VENDOR[0]:
             return _GPU_VENDOR[0]
 
         try:
             vendor = pyvista.GPUInfo().vendor
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # pragma: no cover
             vendor = "UNKNOWN"
 
         # Try to shorten vendor string

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -42,18 +42,18 @@ class _EnvInfo:
     pyvista: bool = True
     vtk: bool = True
     gpu: bool = True
-    host: bool = True
+    ci: bool = True
     suffix: str = ""
 
     def __repr__(self) -> str:
         os_info = _EnvInfo._get_os()
         os_version = f"{os_info[0]}-{os_info[1]}" if self.os else ""
         machine = f"{platform.machine()}" if self.machine else ""
+        gpu = f"gpu-{_EnvInfo._gpu_vendor()}" if self.gpu else ""
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
-        gpu = f"gpu-{_EnvInfo._gpu_vendor()}" if self.gpu else ""
-        host = os.environ.get("RUNNER_ENVIRONMENT", "local-hosted") if self.host else ""
+        ci = f"{'' if os.environ.get('CI', None) else 'no'}-CI" if self.ci else ""
 
         values = [
             f"{self.prefix}",
@@ -63,7 +63,7 @@ class _EnvInfo:
             f"{python_version}",
             f"{pyvista_version}",
             f"{vtk_version}",
-            f"{host}",
+            f"{ci}",
             f"{self.suffix}",
         ]
         return "_".join(val for val in values if val)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -72,11 +72,10 @@ class _EnvInfo:
     def _get_os() -> tuple[str, str]:
         system = platform.system()
         if system == "Linux":
-            if hasattr(platform, "freedesktop_os_release"):
-                # Available python 3.10+
+            try:
                 name = platform.freedesktop_os_release()["ID"]
                 version = platform.freedesktop_os_release()["VERSION_ID"]
-            else:
+            except AttributeError:
                 name = system
                 version = platform.release()
             return name, version

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -98,16 +98,16 @@ class _SystemProperties:
     def _gpu_vendor() -> str:
         try:
             vendor = pyvista.GPUInfo().vendor
-        except Exception:  # noqa: BLE001  # pragma: no cover
+        except Exception:  # noqa: BLE001
             return "unknown"
 
         # Try to shorten vendor string
         lower = vendor.lower()
-        if lower.startswith(nv := "nvidia"):  # pragma: no cover
+        if lower.startswith(nv := "nvidia"):
             text = nv
-        elif lower.startswith(amd := "amd"):  # pragma: no cover
+        elif lower.startswith(amd := "amd"):
             text = amd
-        elif lower.startswith(ati := "ati"):  # pragma: no cover
+        elif lower.startswith(ati := "ati"):
             text = ati
         elif lower.startswith(mesa := "mesa"):
             text = mesa

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -45,7 +45,8 @@ class _EnvInfo:
     suffix: str = ""
 
     def __repr__(self) -> str:
-        system_version = f"{_EnvInfo._get_system()}-{platform.release()}" if self.system else ""
+        os_info = _EnvInfo._get_os()
+        os_version = f"{os_info[0]}-{os_info[1]}" if self.system else ""
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
@@ -54,7 +55,7 @@ class _EnvInfo:
 
         values = [
             f"{self.prefix}",
-            f"{system_version}",
+            f"{os_version}",
             f"{python_version}",
             f"{pyvista_version}",
             f"{vtk_version}",
@@ -65,9 +66,14 @@ class _EnvInfo:
         return "_".join(val for val in values if val)
 
     @staticmethod
-    def _get_system() -> str:
+    def _get_os() -> tuple[str, str]:
         system = platform.system()
-        return "macOS" if system == "Darwin" else system
+        if system == "Linux":
+            import distro  # noqa: PLC0415
+
+            return distro.id(), distro.version()
+        os = "macOS" if system == "Darwin" else system
+        return os, platform.release()
 
     @staticmethod
     def _gpu_vendor() -> str:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -71,8 +71,15 @@ class _EnvInfo:
     @staticmethod
     def _get_os() -> tuple[str, str]:
         system = platform.system()
-
-        name = platform.freedesktop_os_release()["ID"] if system == "Linux" else "macOS" if system == "Darwin" else system
+        if system == "Linux":
+            if hasattr(platform, "freedesktop_os_release"):
+                name = platform.freedesktop_os_release()["ID"]
+                version = platform.freedesktop_os_release()["VERSION_ID"]
+            else:
+                name = system
+                version = platform.release()
+            return name, version
+        name = "macOS" if system == "Darwin" else system
         return name, platform.release()
 
     @staticmethod

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -299,7 +299,6 @@ class VerifyImageCache:
     add_missing_images = False
     reset_only_failed = False
     generate_subdirs = None
-    env_info: _EnvInfo
 
     def __init__(  # noqa: PLR0913
         self,
@@ -315,6 +314,7 @@ class VerifyImageCache:
     ) -> None:
         """Initialize VerifyImageCache."""
         self.test_name = test_name
+        self.env_info: str | _EnvInfo = _EnvInfo()
 
         # handle paths
         if not cache_dir.is_dir():
@@ -677,7 +677,6 @@ def verify_image_cache(
     VerifyImageCache.add_missing_images = pytestconfig.getoption("add_missing_images")
     VerifyImageCache.reset_only_failed = pytestconfig.getoption("reset_only_failed")
     VerifyImageCache.generate_subdirs = pytestconfig.getoption("generate_subdirs")
-    VerifyImageCache.env_info = _EnvInfo()
 
     cache_dir = cast("Path", _get_option_from_config_or_ini(pytestconfig, "image_cache_dir", is_dir=True))
     gen_dir = _get_option_from_config_or_ini(pytestconfig, "generated_image_dir", is_dir=True)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -41,7 +41,7 @@ class _EnvInfo:
     pyvista: bool = True
     vtk: bool = True
     gpu: bool = True
-    runner: bool = True
+    host: bool = True
     suffix: str = ""
 
     def __repr__(self) -> str:
@@ -50,7 +50,7 @@ class _EnvInfo:
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
         gpu = f"gpu-{_EnvInfo._gpu_vendor()}" if self.gpu else ""
-        runner = os.environ.get("RUNNER_ENVIRONMENT", "local-hosted") if self.runner else ""
+        host = os.environ.get("RUNNER_ENVIRONMENT", "local-hosted") if self.host else ""
 
         values = [
             f"{self.prefix}",
@@ -59,7 +59,7 @@ class _EnvInfo:
             f"{pyvista_version}",
             f"{vtk_version}",
             f"{gpu}",
-            f"{runner}",
+            f"{host}",
             f"{self.suffix}",
         ]
         return "_".join(val for val in values if val)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -36,7 +36,7 @@ _GPU_VENDOR: list[str] = [""]  # Use a list so we can mutate the string globally
 @dataclass
 class _EnvInfo:
     prefix: str = ""
-    system: bool = True
+    os: bool = True
     python: bool = True
     pyvista: bool = True
     vtk: bool = True
@@ -46,7 +46,7 @@ class _EnvInfo:
 
     def __repr__(self) -> str:
         os_info = _EnvInfo._get_os()
-        os_version = f"{os_info[0]}-{os_info[1]}" if self.system else ""
+        os_version = f"{os_info[0]}-{os_info[1]}" if self.os else ""
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -68,12 +68,9 @@ class _EnvInfo:
     @staticmethod
     def _get_os() -> tuple[str, str]:
         system = platform.system()
-        if system == "Linux":
-            import distro  # noqa: PLC0415
 
-            return distro.id(), distro.version()
-        os = "macOS" if system == "Darwin" else system
-        return os, platform.release()
+        name = platform.freedesktop_os_release()["ID"] if system == "Linux" else "macOS" if system == "Darwin" else system
+        return name, platform.release()
 
     @staticmethod
     def _gpu_vendor() -> str:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -53,7 +53,7 @@ class _EnvInfo:
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
-        ci = f"{'' if os.environ.get('CI', None) else 'no'}-CI" if self.ci else ""
+        ci = f"{'' if os.environ.get('CI', None) else 'no-'}CI" if self.ci else ""
 
         values = [
             f"{self.prefix}",

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -44,14 +44,8 @@ class _EnvInfo:
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
-        return "_".join(
-            [
-                f"{self.prefix}{'_' if self.prefix else ''}{system_version}",
-                f"{python_version}",
-                f"{pyvista_version}",
-                f"{vtk_version}{'_' if self.suffix else ''}{self.suffix}",
-            ]
-        )
+        values = [f"{self.prefix}", f"{system_version}", f"{python_version}", f"{pyvista_version}", f"{vtk_version}", f"{self.suffix}"]
+        return "_".join(val for val in values if val)
 
     @staticmethod
     def _get_system() -> str:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -37,6 +37,7 @@ class _EnvInfo:
     python: bool = True
     pyvista: bool = True
     vtk: bool = True
+    runner: bool = True
     suffix: str = ""
 
     def __repr__(self) -> str:
@@ -44,7 +45,8 @@ class _EnvInfo:
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
-        values = [f"{self.prefix}", f"{system_version}", f"{python_version}", f"{pyvista_version}", f"{vtk_version}", f"{self.suffix}"]
+        runner = os.environ.get("RUNNER_ENVIRONMENT", "local") if self.runner else ""
+        values = [f"{self.prefix}", f"{system_version}", f"{python_version}", f"{pyvista_version}", f"{vtk_version}", f"{runner}", f"{self.suffix}"]
         return "_".join(val for val in values if val)
 
     @staticmethod

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -37,6 +37,7 @@ _GPU_VENDOR: list[str] = [""]  # Use a list so we can mutate the string globally
 class _EnvInfo:
     prefix: str = ""
     os: bool = True
+    machine: bool = True
     python: bool = True
     pyvista: bool = True
     vtk: bool = True
@@ -47,6 +48,7 @@ class _EnvInfo:
     def __repr__(self) -> str:
         os_info = _EnvInfo._get_os()
         os_version = f"{os_info[0]}-{os_info[1]}" if self.os else ""
+        machine = f"{platform.machine()}" if self.machine else ""
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
@@ -56,6 +58,7 @@ class _EnvInfo:
         values = [
             f"{self.prefix}",
             f"{os_version}",
+            f"{machine}",
             f"{python_version}",
             f"{pyvista_version}",
             f"{vtk_version}",

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -40,10 +40,7 @@ class _EnvInfo:
     suffix: str = ""
 
     def __repr__(self) -> str:
-        system = platform.system()
-        if system == "Darwin":
-            system = "macOS"
-        system_version = f"{system}-{platform.release()}" if self.system else ""
+        system_version = f"{_EnvInfo._get_system()}-{platform.release()}" if self.system else ""
         python_version = f"py-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}" if self.python else ""
         pyvista_version = f"pyvista-{pyvista.__version__}" if self.pyvista else ""
         vtk_version = f"vtk-{vtkmodules.__version__}" if self.vtk else ""
@@ -55,6 +52,11 @@ class _EnvInfo:
                 f"{vtk_version}{'_' if self.suffix else ''}{self.suffix}",
             ]
         )
+
+    @staticmethod
+    def _get_system() -> str:
+        system = platform.system()
+        return "macOS" if system == "Darwin" else system
 
 
 class RegressionError(RuntimeError):

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -73,6 +73,7 @@ class _EnvInfo:
         system = platform.system()
         if system == "Linux":
             if hasattr(platform, "freedesktop_os_release"):
+                # Available python 3.10+
                 name = platform.freedesktop_os_release()["ID"]
                 version = platform.freedesktop_os_release()["VERSION_ID"]
             else:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -82,16 +82,16 @@ class _EnvInfo:
 
         # Try to shorten vendor string
         lower = vendor.lower()
-        if lower.startswith(nv := "nvidia"):
+        if lower.startswith(nv := "nvidia"):  # pragma: no cover
             text = nv
-        elif lower.startswith(amd := "amd"):
+        elif lower.startswith(amd := "amd"):  # pragma: no cover
             text = amd
-        elif lower.startswith(ati := "ati"):
+        elif lower.startswith(ati := "ati"):  # pragma: no cover
             text = ati
         elif lower.startswith(mesa := "mesa"):
             text = mesa
         else:
-            text = vendor
+            text = vendor  # pragma: no cover
         # Shorten original string and remove whitespace
         vendor = vendor[: len(text)].replace(" ", "")
         # Remove all potentially invalid/undesired filename characters

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -99,7 +99,7 @@ class _SystemProperties:
         try:
             vendor = pyvista.GPUInfo().vendor
         except Exception:  # noqa: BLE001  # pragma: no cover
-            vendor = "UNKNOWN"
+            return "unknown"
 
         # Try to shorten vendor string
         lower = vendor.lower()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -59,10 +59,10 @@ class _EnvInfo:
             f"{self.prefix}",
             f"{os_version}",
             f"{machine}",
+            f"{gpu}",
             f"{python_version}",
             f"{pyvista_version}",
             f"{vtk_version}",
-            f"{gpu}",
             f"{host}",
             f"{self.suffix}",
         ]

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1030,6 +1030,7 @@ def test_env_info() -> None:
     """Test env info dataclass."""
     info = str(_EnvInfo())
     system = _EnvInfo._get_system()  # noqa:SLF001
+    assert " " not in info
     assert info.startswith(system + "-")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)
@@ -1040,8 +1041,8 @@ def test_env_info() -> None:
     assert any(m.startswith("_pyvista-") for m in matches), f"No pyvista version found in {info}"
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
-    assert "gpu-" in info
-    assert "-hosted" in info
+    assert any(f"gpu-{vendor.lower()}" in info.lower() for vendor in ["Apple", "NVIDIA", "Mesa", "AMD", "ATI"])
+    assert any(hosted in info for hosted in ["self-hosted", "github-hosted", "local-hosted"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1040,9 +1040,9 @@ def test_env_info() -> None:
     pattern = r"_[a-zA-Z]+-\d+\.\d+\.\d+(?:[a-zA-Z0-9\.]*)?"
     matches = re.findall(pattern, info)
 
-    assert any(m.startswith("_py-") for m in matches), f"No pyvista version found in {info}"
-    assert any(m.startswith("_pyvista-") for m in matches), f"No pyvista version found in {info}"
-    assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
+    assert any(m.startswith("_py-") for m in matches)
+    assert any(m.startswith("_pyvista-") for m in matches)
+    assert any(m.startswith("_vtk-") for m in matches)
 
     assert any(f"gpu-{vendor.lower()}" in info.lower() for vendor in ["Apple", "NVIDIA", "Mesa", "AMD", "ATI"])
 
@@ -1062,7 +1062,7 @@ def test_env_info() -> None:
         ("python", "py-"),
         ("pyvista", "pyvista-"),
         ("vtk", "vtk-"),
-        ("ci", "-CI"),
+        ("ci", "CI"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:
@@ -1075,6 +1075,8 @@ def test_env_info_exclude(name: str, value: str) -> None:
     info = str(_EnvInfo(**{name: False}))
     assert value not in info
     assert "__" not in info
+    assert "_-" not in info
+    assert "-_" not in info
 
 
 def test_env_info_prefix_suffix() -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1051,7 +1051,7 @@ def test_env_info() -> None:
 @pytest.mark.parametrize(
     ("name", "value"),
     [
-        ("system", _EnvInfo._get_os()),  # noqa: SLF001
+        ("os", _EnvInfo._get_os()[0]),  # noqa: SLF001
         ("python", "python"),
         ("pyvista", "pyvista"),
         ("vtk", "vtk"),

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1033,7 +1033,7 @@ def test_env_info() -> None:
     os_info = _EnvInfo._get_os()  # noqa:SLF001
     assert " " not in info
     assert info.startswith(os_info[0] + "-" + os_info[1])
-    if os.environ.get("CI") and platform.system() == "Linux" and sys.version_info >= (3, 10):
+    if platform.system() == "Linux" and sys.version_info >= (3, 10):
         assert info.startswith("ubuntu")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)
@@ -1045,7 +1045,12 @@ def test_env_info() -> None:
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
     assert any(f"gpu-{vendor.lower()}" in info.lower() for vendor in ["Apple", "NVIDIA", "Mesa", "AMD", "ATI"])
-    assert any(host in info for host in ["self-hosted", "github-hosted", "local-hosted"])
+
+    if os.environ.get("CI", None):
+        assert "no-CI" not in info
+        assert "CI" in info
+    else:
+        assert "no-CI" in info
 
 
 @pytest.mark.parametrize(
@@ -1053,11 +1058,11 @@ def test_env_info() -> None:
     [
         ("os", _EnvInfo._get_os()[0]),  # noqa: SLF001
         ("machine", platform.machine()),
+        ("gpu", "gpu-"),
         ("python", "py-"),
         ("pyvista", "pyvista-"),
         ("vtk", "vtk-"),
-        ("gpu", "gpu-"),
-        ("host", "-hosted"),
+        ("ci", "-CI"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1042,7 +1042,7 @@ def test_env_info() -> None:
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
     assert any(f"gpu-{vendor.lower()}" in info.lower() for vendor in ["Apple", "NVIDIA", "Mesa", "AMD", "ATI"])
-    assert any(hosted in info for hosted in ["self-hosted", "github-hosted", "local-hosted"])
+    assert any(host in info for host in ["self-hosted", "github-hosted", "local-hosted"])
 
 
 @pytest.mark.parametrize(
@@ -1053,7 +1053,7 @@ def test_env_info() -> None:
         ("pyvista", "pyvista"),
         ("vtk", "vtk"),
         ("gpu", "gpu"),
-        ("runner", "hosted"),
+        ("host", "hosted"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 import filecmp
+import os
 from pathlib import Path
 import platform
 import re
@@ -1040,14 +1041,18 @@ def test_env_info() -> None:
     assert any(m.startswith("_pyvista-") for m in matches), f"No pyvista version found in {info}"
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
+    expected_runner = "-hosted" in info if os.environ.get("CI", None) else "local"
+    assert expected_runner in info
+
 
 @pytest.mark.parametrize(
     ("name", "value"),
     [
-        ("python", "python"),
-        ("vtk", "vtk"),
         ("system", _EnvInfo._get_system()),  # noqa: SLF001
+        ("python", "python"),
         ("pyvista", "pyvista"),
+        ("vtk", "vtk"),
+        ("runner", "-hosted" if os.environ.get("CI", None) else "local"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1041,7 +1041,7 @@ def test_env_info() -> None:
     assert any(m.startswith("_pyvista-") for m in matches), f"No pyvista version found in {info}"
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
-    expected_runner = "-hosted" in info if os.environ.get("CI", None) else "local"
+    expected_runner = "-hosted" if os.environ.get("CI", None) else "local"
     assert expected_runner in info
 
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1033,7 +1033,7 @@ def test_env_info() -> None:
     os_info = _EnvInfo._get_os()  # noqa:SLF001
     assert " " not in info
     assert info.startswith(os_info[0] + "-" + os_info[1])
-    if os.environ.get("CI") and platform.system() == "Linux":
+    if os.environ.get("CI") and platform.system() == "Linux" and sys.version_info >= (3, 10):
         assert info.startswith("ubuntu")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1039,8 +1039,11 @@ def test_env_info() -> None:
     info = str(_EnvInfo())
     assert " " not in info
     assert info.startswith(f"{_SYSTEM_PROPERTIES.os_name}-{_SYSTEM_PROPERTIES.os_version}")
-    if platform.system() == "Linux" and sys.version_info >= (3, 10):
-        assert info.startswith("ubuntu")
+    if platform.system() == "Linux":
+        if sys.version_info >= (3, 10):
+            assert info.startswith("ubuntu")
+        else:
+            assert info.startswith("Linux")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)
     pattern = r"_[a-zA-Z]+-\d+\.\d+\.\d+(?:[a-zA-Z0-9\.]*)?"
@@ -1125,6 +1128,7 @@ def test_gpu_vendor_unknown(mocker: MockerFixture) -> None:
     assert _SystemProperties._gpu_vendor() == "unknown"  # noqa: SLF001
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Missing freedesktop_os_release")
 def test_os_linux_freedesktop(mocker: MockerFixture) -> None:
     """Test system properties for Linux."""
     mocker.patch("platform.system", return_value="Linux")

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1016,15 +1016,10 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
             assert file_has_changed(str(from_test), str(from_cache))
 
 
-def _get_system() -> str:
-    system = platform.system()
-    return "macOS" if system == "Darwin" else system
-
-
 def test_env_info() -> None:
     """Test env info dataclass."""
     info = str(_EnvInfo())
-    system = _get_system()
+    system = _EnvInfo._get_system()  # noqa:SLF001
     assert info.startswith(system + "-")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)
@@ -1036,7 +1031,15 @@ def test_env_info() -> None:
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
 
-@pytest.mark.parametrize(("name", "value"), [("python", "python"), ("vtk", "vtk"), ("system", _get_system()), ("pyvista", "pyvista")])
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("python", "python"),
+        ("vtk", "vtk"),
+        ("system", _EnvInfo._get_system()),  # noqa: SLF001
+        ("pyvista", "pyvista"),
+    ],
+)
 def test_env_info_exclude(name: str, value: str) -> None:
     """Test removing parts of the env info."""
     info = str(_EnvInfo(**{name: False}))

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1052,15 +1052,21 @@ def test_env_info() -> None:
     ("name", "value"),
     [
         ("os", _EnvInfo._get_os()[0]),  # noqa: SLF001
-        ("python", "python"),
-        ("pyvista", "pyvista"),
-        ("vtk", "vtk"),
-        ("gpu", "gpu"),
-        ("host", "hosted"),
+        ("machine", platform.machine()),
+        ("python", "py-"),
+        ("pyvista", "pyvista-"),
+        ("vtk", "vtk-"),
+        ("gpu", "gpu-"),
+        ("host", "-hosted"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:
     """Test removing parts of the env info."""
+    # Sanity check to ensure the value is there ordinarily
+    info = str(_EnvInfo())
+    assert value in info
+
+    # Test it's excluded
     info = str(_EnvInfo(**{name: False}))
     assert value not in info
     assert "__" not in info

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from enum import Enum
 import filecmp
-import os
 from pathlib import Path
 import platform
 import re
@@ -1041,8 +1040,8 @@ def test_env_info() -> None:
     assert any(m.startswith("_pyvista-") for m in matches), f"No pyvista version found in {info}"
     assert any(m.startswith("_vtk-") for m in matches), f"No vtk version found in {info}"
 
-    expected_runner = "-hosted" if os.environ.get("CI", None) else "local"
-    assert expected_runner in info
+    assert "gpu-" in info
+    assert "-hosted" in info
 
 
 @pytest.mark.parametrize(
@@ -1052,7 +1051,8 @@ def test_env_info() -> None:
         ("python", "python"),
         ("pyvista", "pyvista"),
         ("vtk", "vtk"),
-        ("runner", "-hosted" if os.environ.get("CI", None) else "local"),
+        ("gpu", "gpu"),
+        ("runner", "hosted"),
     ],
 )
 def test_env_info_exclude(name: str, value: str) -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 import pytest
 import pyvista as pv
 
+from pytest_pyvista.pytest_pyvista import _SYSTEM_PROPERTIES
 from pytest_pyvista.pytest_pyvista import _EnvInfo
 
 pv.OFF_SCREEN = True
@@ -1030,9 +1031,8 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
 def test_env_info() -> None:
     """Test env info dataclass."""
     info = str(_EnvInfo())
-    os_info = _EnvInfo._get_os()  # noqa:SLF001
     assert " " not in info
-    assert info.startswith(os_info[0] + "-" + os_info[1])
+    assert info.startswith(f"{_SYSTEM_PROPERTIES.os_name}-{_SYSTEM_PROPERTIES.os_version}")
     if platform.system() == "Linux" and sys.version_info >= (3, 10):
         assert info.startswith("ubuntu")
 
@@ -1056,7 +1056,7 @@ def test_env_info() -> None:
 @pytest.mark.parametrize(
     ("name", "value"),
     [
-        ("os", _EnvInfo._get_os()[0]),  # noqa: SLF001
+        ("os", _SYSTEM_PROPERTIES.os_name),
         ("machine", platform.machine()),
         ("gpu", "gpu-"),
         ("python", "py-"),

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 import filecmp
+import os
 from pathlib import Path
 import platform
 import re
@@ -1029,9 +1030,11 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
 def test_env_info() -> None:
     """Test env info dataclass."""
     info = str(_EnvInfo())
-    system = _EnvInfo._get_system()  # noqa:SLF001
+    os_info = _EnvInfo._get_os()  # noqa:SLF001
     assert " " not in info
-    assert info.startswith(system + "-")
+    assert info.startswith(os_info[0] + "-" + os_info[1])
+    if os.environ.get("CI") and platform.system() == "Linux":
+        assert info.startswith("ubuntu")
 
     # Generic regex for "_package-#.#.#" with optional suffix (like .dev0, .post1, etc.)
     pattern = r"_[a-zA-Z]+-\d+\.\d+\.\d+(?:[a-zA-Z0-9\.]*)?"
@@ -1048,7 +1051,7 @@ def test_env_info() -> None:
 @pytest.mark.parametrize(
     ("name", "value"),
     [
-        ("system", _EnvInfo._get_system()),  # noqa: SLF001
+        ("system", _EnvInfo._get_os()),  # noqa: SLF001
         ("python", "python"),
         ("pyvista", "pyvista"),
         ("vtk", "vtk"),


### PR DESCRIPTION
Allow customizing info saved in image filenames when using `--generate_subdirs`. See https://github.com/pyvista/pytest-pyvista/pull/211#pullrequestreview-3183786750 for details.

Adds a new dataclass with the option to customize it using `verify_image_cache.env_info`.