### PR TITLE
Use self-hosted and 8 threads

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,7 +173,7 @@ jobs:
 
   downstream:
     name: Downstream tests
-    runs-on: ubuntu-22.04 # matching pyvista
+    runs-on: ubuntu-22.04-self-hosted # matching pyvista
     steps:
       - uses: actions/checkout@v5
 
@@ -200,7 +200,7 @@ jobs:
           pip list
 
       - name: Unit Testing
-        run: xvfb-run python -m pytest -v --allow_useless_fixture --generated_image_dir gen_dir tests/plotting --disallow_unused_cache -n2
+        run: xvfb-run python -m pytest -v --allow_useless_fixture --generated_image_dir gen_dir tests/plotting --disallow_unused_cache -n8
         working-directory: /tmp/pyvista
 
       - name: Upload generated image artifact


### PR DESCRIPTION
Use self-hosted and 8 threads. Not strictly necessary, but downstream tests are the long pole in the tent for CI.