### PR TITLE
Allow separate image format for doc mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ These are the flags you can use when calling ``pytest`` in the command line:
   failures. It is relative to `pytest root path <https://docs.pytest.org/en/latest/reference/reference.html#pytest.Config.rootpath>`.
   This will override any configuration, see below.
 
-* Use ``--image_format`` to save test images in either ``png`` or ``jpg`` format.
+* Use ``--doc_image_format`` to save test images in either ``png`` or ``jpg`` format.
   ``png`` files are saved by default. Use ``jpg`` to reduce the image file size.
   This will override any configuration, see below.
 
@@ -371,12 +371,13 @@ Configure directories for when ``--doc_mode`` is used:
 
 Note that these directories are relative to `pytest root path <https://docs.pytest.org/en/latest/reference/reference.html#pytest.Config.rootpath>`.
 
-Configure the image format to be ``jpg``:
+Configure the image format to be ``jpg`` for both unit tests and when using ``--doc_mode``.
 
 .. code-block:: toml
 
     [tool.pytest.ini_options]
     image_format = "jpg"
+    doc_image_format = "jpg"
 
 Contributing
 ------------

--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -31,7 +31,7 @@ class _DocModeInfo:
     doc_image_cache_dir: Path
     doc_generated_image_dir: Path
     doc_failed_image_dir: Path
-    image_format: _ImageFormats
+    doc_image_format: _ImageFormats
     _tempdirs: ClassVar[list[tempfile.TemporaryDirectory]] = []
 
     @classmethod
@@ -131,13 +131,13 @@ def _generate_test_cases() -> list[_TestCaseTuple]:
 
     # process test images
     test_image_paths = _preprocess_build_images(
-        _DocModeInfo.doc_images_dir, _DocModeInfo.doc_generated_image_dir, image_format=_DocModeInfo.image_format
+        _DocModeInfo.doc_images_dir, _DocModeInfo.doc_generated_image_dir, image_format=_DocModeInfo.doc_image_format
     )
     [add_to_dict(path, "docs") for path in test_image_paths]  # type: ignore[func-returns-value]
 
     # process cached images
     cache_dir = _DocModeInfo.doc_image_cache_dir
-    cached_image_paths = _get_file_paths(cache_dir, ext=_DocModeInfo.image_format)
+    cached_image_paths = _get_file_paths(cache_dir, ext=_DocModeInfo.doc_image_format)
     for path in cached_image_paths:
         # Check if we have a single image or a dir with multiple images
         rel = path.relative_to(cache_dir)
@@ -202,7 +202,7 @@ def test_static_images(test_case: _TestCaseTuple) -> None:
     cached_image_paths = (
         [test_case.cached_image_path]
         if test_case.cached_image_path.is_file()
-        else _get_file_paths(test_case.cached_image_path, ext=_DocModeInfo.image_format)
+        else _get_file_paths(test_case.cached_image_path, ext=_DocModeInfo.doc_image_format)
     )
     current_cached_image_path = cached_image_paths[0]
 
@@ -273,7 +273,7 @@ def _test_both_images_exist(filename: str, docs_image_path: Path, cached_image_p
 def _warn_cached_image_path(cached_image_path: Path) -> None:
     """Warn if a subdir is used with only one cached image."""
     if cached_image_path is not None and cached_image_path.is_dir():
-        cached_images = _get_file_paths(cached_image_path, ext=_DocModeInfo.image_format)
+        cached_images = _get_file_paths(cached_image_path, ext=_DocModeInfo.doc_image_format)
         if len(cached_images) == 1:
             cache_dir = _DocModeInfo.doc_image_cache_dir
             rel_path = cache_dir.name / cached_images[0].relative_to(cache_dir)

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -189,18 +189,6 @@ def pytest_addoption(parser) -> None:  # noqa: ANN001
         action="store_true",
         help="Prevent test failure if the `verify_image_cache` fixture is used but no images are generated.",
     )
-    group.addoption(
-        "--image_format",
-        action="store",
-        choices=get_args(_ImageFormats),
-        default=None,
-        help="Image format to use when generating test images.",
-    )
-    parser.addini(
-        "image_format",
-        default="png",
-        help="Image format to use when generating test images.",
-    )
 
     # Doc-specific test options
     group.addoption(
@@ -253,6 +241,18 @@ def _add_common_pytest_options(parser, *, doc: bool = False) -> None:  # noqa: A
         f"{prefix}failed_image_dir",
         default=None,
         help="Path to dump images from failed tests from the current run.",
+    )
+    group.addoption(
+        f"--{prefix}image_format",
+        action="store",
+        choices=get_args(_ImageFormats),
+        default=None,
+        help="Image format to use when generating test images.",
+    )
+    parser.addini(
+        f"{prefix}image_format",
+        default="png",
+        help="Image format to use when generating test images.",
     )
 
 
@@ -698,7 +698,7 @@ def pytest_configure(config: pytest.Config) -> None:
         from pytest_pyvista.doc_mode import _DocModeInfo  # noqa: PLC0415
 
         _DocModeInfo.init_dirs(config)
-        _DocModeInfo.image_format = cast("_ImageFormats", _get_option_from_config_or_ini(config, "image_format"))
+        _DocModeInfo.doc_image_format = cast("_ImageFormats", _get_option_from_config_or_ini(config, "doc_image_format"))
 
     # create a image names directory for individual or multiple workers to write to
     if config.getoption("disallow_unused_cache"):

--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -27,7 +27,7 @@ def test_doc_mode(pytester: pytest.Pytester, generated_image_dir, image_format: 
     make_cached_images(pytester.path, images, name=name)
     _preprocess_build_images(pytester.path / cache, pytester.path / cache, image_format=image_format)
 
-    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--image_format", image_format]
+    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--doc_image_format", image_format]
     generated = "generated"
     if generated_image_dir:
         args.extend(["--doc_generated_image_dir", generated])
@@ -87,7 +87,9 @@ def test_both_images_exist(pytester: pytest.Pytester, missing: str, image_format
 
     images_path.mkdir(exist_ok=True)
     cache_path.mkdir(exist_ok=True)
-    result = pytester.runpytest("--doc_mode", "--doc_images_dir", images_path, "--doc_image_cache_dir", cache_path, "--image_format", image_format)
+    result = pytester.runpytest(
+        "--doc_mode", "--doc_images_dir", images_path, "--doc_image_cache_dir", cache_path, "--doc_image_format", image_format
+    )
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(["*Failed: Test setup failed for test image:*", *expected_lines])
 
@@ -134,7 +136,7 @@ def test_compare_images_warning(pytester: pytest.Pytester, *, failed_image_dir: 
     make_cached_images(pytester.path, images, name=name, color=[240, 0, 0])
     _preprocess_build_images(pytester.path / cache, pytester.path / cache, image_format=image_format)
 
-    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--image_format", image_format]
+    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--doc_image_format", image_format]
     failed = "failed"
     if failed_image_dir:
         args.extend(["--doc_failed_image_dir", failed])
@@ -185,7 +187,7 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
     build_filename = make_cached_images(pytester.path, images, name=name, color=build_color)
     _preprocess_build_images(cache_parent / subdir, cache_parent / subdir, image_format=image_format)
 
-    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--image_format", image_format]
+    args = ["--doc_mode", "--doc_images_dir", images, "--doc_image_cache_dir", cache, "--doc_image_format", image_format]
     failed = "failed"
     if failed_image_dir:
         args.extend(["--doc_failed_image_dir", failed])
@@ -326,7 +328,7 @@ def test_ini(*, pytester: pytest.Pytester, cli: bool) -> None:
     pytester.makeini(
         f"""
         [pytest]
-        image_format = {image_format_ini}
+        doc_image_format = {image_format_ini}
         doc_failed_image_dir = {failed_ini}
         doc_generated_image_dir = {generated_ini}
         doc_image_cache_dir = {cache_ini}
@@ -346,7 +348,7 @@ def test_ini(*, pytester: pytest.Pytester, cli: bool) -> None:
                 failed_cli,
                 "--doc_generated_image_dir",
                 generated_cli,
-                "--image_format",
+                "--doc_image_format",
                 image_format_cli,
             ]
         )


### PR DESCRIPTION
The doc mode options should all be prefixed with `doc` to distinguish them from regular unit test options. This will allow specifying both options in the config file:
``` toml
[tool.pytest.ini_options]
image_format = 'png'
doc_image_format = 'jpg'
```