### PR TITLE
Validate doc mode CLI args are only used with `--doc_mode`

### DIFF
--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1174,3 +1174,16 @@ def test_os_darwin_windows(
 
     result = _SystemProperties._get_os()  # noqa: SLF001
     assert result == expected
+
+
+def test_invalid_cli_args(pytester: pytest.Pytester) -> None:
+    """Test using wrong CLI args related to doc mode."""
+    # Test 'doc' arg without --doc_mode
+    result = pytester.runpytest("--doc_image_format", "png")
+    assert result.ret == pytest.ExitCode.INTERNAL_ERROR
+    result.stderr.fnmatch_lines("INTERNALERROR> RuntimeError: Argument --doc_image_format is only valid when using --doc_mode")
+
+    # Test no 'doc' arg with --doc_mode
+    result = pytester.runpytest("--doc_mode", "--image_format", "png")
+    assert result.ret == pytest.ExitCode.INTERNAL_ERROR
+    result.stderr.fnmatch_lines("INTERNALERROR> RuntimeError: Argument --image_format is not valid when using --doc_mode")


### PR DESCRIPTION
Raise an error if using any doc-specific args without also using `--doc_mode`.