### PR TITLE
Drop support for Python 3.9 and VTK 9.1

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,8 +59,6 @@ jobs:
 
       matrix:
         include:
-          - python-version: "3.9"
-            vtk-version: "9.1"
           - python-version: "3.10"
             vtk-version: "9.2.2"
           - python-version: "3.11"
@@ -93,10 +91,6 @@ jobs:
         if: ${{ matrix.vtk-version != 'latest' }}
         run: pip install vtk==${{ matrix.vtk-version }}
 
-      - name: Limit NumPy for VTK 9.0.3
-        if: ${{ matrix.vtk-version == '9.0.3' }}
-        run: pip install 'numpy<1.24'
-
       - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
@@ -120,7 +114,7 @@ jobs:
         run: coverage combine || true
 
       - uses: codecov/codecov-action@v5
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         name: "Upload coverage to CodeCov"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,10 @@ fail.
 
 Requirements
 ------------
-You must have a Python version >= 3.9, as well as PyVista installed
+You must have a Python version >= 3.10, as well as PyVista installed
 in your environment.
 
-pyvista version >=0.37.0 and vtk version >=9.0.0 required.
+pyvista version >=0.37.0 and vtk version >=9.2.2 required.
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.9",
   "Topic :: Software Development :: Testing",
 ]
 dependencies = ["pytest>=6.2.0"]
@@ -21,7 +20,7 @@ dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]
 name = "pytest_pyvista"
-python_requires = ">=3.9"
+python_requires = ">=3.10"
 readme = "README.rst"
 
 [project.urls]


### PR DESCRIPTION
Python 3.9 reaches EOL on October 30. I propose dropping support for it. `pyvista` has already done so downstream.

My main motivation is that I'm seeing seg faults with #227 for vtk 9.1 with python 3.9, and so some tests are skipped, but coverage is only reported for 3.9, and hence missing coverage is being reported even though it is covered by later versions.

I don't think these seg faults are necessarily inherent to vtk 9.1, and may be an issue with our CI (tests that were previously passing are now failing as additional tests were added), but instead of trying to isolate and fix this I think it may be better to drop support completely based on python 3.9 EOL.