### PR TITLE
Remove warning for single image in subdir

### DIFF
--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -456,7 +456,6 @@ def max_vtksz_file_size(request: pytest.FixtureRequest) -> _VtkszFileSizeTestCas
 def test_images(_pytest_pyvista_test_case: _DocVerifyImageCache, doc_verify_image_cache: _DocVerifyImageCache) -> None:  # noqa: PT019, ARG001
     """Compare generated image with cached image."""
     test_case = _pytest_pyvista_test_case
-    _warn_cached_image_path(test_case.cached_image_path)
     fail_msg, fail_source = _test_both_images_exist(
         filename=test_case.test_name, docs_image_path=test_case.test_image_path, cached_image_path=test_case.cached_image_path
     )
@@ -548,21 +547,6 @@ def _test_both_images_exist(filename: str, docs_image_path: Path | None, cached_
         )
         return msg, source_path
     return None, None
-
-
-def _warn_cached_image_path(cached_image_path: Path | None) -> None:
-    """Warn if a subdir is used with only one cached image."""
-    if cached_image_path is not None and cached_image_path.is_dir():
-        cached_images = _get_file_paths(cached_image_path, ext=_DocVerifyImageCache.image_format)
-        if len(cached_images) == 1:
-            cache_dir = _DocVerifyImageCache.image_cache_dir
-            rel_path = cache_dir.name / cached_images[0].relative_to(cache_dir)
-            msg = (
-                "Cached image sub-directory only contains a single image.\n"
-                f"Move the cached image {rel_path.as_posix()!r} directly to the cached image dir {cache_dir.name!r}\n"
-                f"or include more than one image in the sub-directory."
-            )
-            warnings.warn(msg, stacklevel=2)
 
 
 def test_vtksz_file_size(_pytest_pyvista_test_case_vtksz: _VtkszFileSizeTestCase, max_vtksz_file_size: _VtkszFileSizeTestCase) -> None:  # noqa: PT019, ARG001

--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -299,25 +299,6 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
             assert file_has_changed(str(from_build), str(from_cache))
 
 
-def test_single_cache_image_in_subdir(pytester: pytest.Pytester) -> None:
-    """Test that a warning is emitting for a cache subdir with only one image."""
-    cache = "cache"
-    images = "images"
-    subdir = "imcache"
-    make_cached_images(pytester.path / cache, subdir)
-    make_cached_images(pytester.path, images)
-    _preprocess_build_images(pytester.path / cache / subdir, pytester.path / cache / subdir)
-
-    result = pytester.runpytest("--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache)
-    assert result.ret == pytest.ExitCode.OK
-    match = [
-        ".*UserWarning: Cached image sub-directory only contains a single image.",
-        ".*Move the cached image 'cache/imcache/imcache.png' directly to the cached image dir 'cache'",
-        ".*or include more than one image in the sub-directory.",
-    ]
-    result.stdout.re_match_lines(match)
-
-
 @pytest.mark.parametrize("include_vtksz", [True, False])
 def test_multiple_cache_images_parallel(pytester: pytest.Pytester, include_vtksz) -> None:
     """Ensure that doc_mode works with multiple workers."""


### PR DESCRIPTION
Remove unnecessary warning, see https://github.com/pyvista/pytest-pyvista/pull/198#discussion_r2320256552