### PR TITLE
Refactor `pytest_addoption` common options

### DIFF
--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -233,7 +233,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
         option = "image_format"
         help_ = "Image format to use when generating test images."
         _add_common_cli_option(f"--{option}", action="store", choices=get_args(_AllowedImageFormats), default=None, help=help_)
-        _add_common_ini_option(option, default=None, help=help_) # Default is set when getting from config or ini
+        _add_common_ini_option(option, default=None, help=help_)  # Default is set when getting from config or ini
 
     def _add_unit_test_cli_and_ini_options() -> None:
         """Add options specific to regular unit tests."""


### PR DESCRIPTION
Currently, `_add_common_cli_and_ini_options` is called twice (with `doc=True`, and `doc=False`). But, the only thing this does is append a second INI option with a `doc_` prefix. This PR adds `_add_common_ini_option` to do this instead so that `_add_common_cli_and_ini_options` only needs to be called once.

To better separate the addition of unit test options from doc options, these are also nested into separate functions.