### PR TITLE
Bump dev version to v0.4.dev0

### DIFF
--- a/pytest_pyvista/__init__.py
+++ b/pytest_pyvista/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.dev0"
+__version__ = "0.4.dev0"
 
 from .pytest_pyvista import VerifyImageCache  # noqa: F401


### PR DESCRIPTION
Bump the version on `main` to `0.4.dev0`.

With the release of `pytest-pyvista==0.3.0`, dev version should be the next minor version with `dev0`, following the specitifactions of [PEP 440](https://peps.python.org/pep-0440/).
