### PR TITLE
Remove upper bounds on vtksz dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
   "pytest_mock<3.16",
   "pyvista[jupyter]>=0.37",
 ]
-vtksz = ["playwright<1.56", "trame-vtk<2.11", "trame-vtk>=2.6"]
+vtksz = ["playwright", "trame-vtk>=2.6"]
 
 [project.entry-points."pytest11"]
 # Location of the plugin module, in this case ./pytest_pyvista/pytest_pyvista.py


### PR DESCRIPTION
This is a user-facing dependency and should not have upper bounds on the versions. Having an upper bound is blocking https://github.com/pyvista/pyvista/pull/8047

We _could_ add a new `vtksz` dependency group and pin these deps there for internal testing purposes only, but maybe that's not necessary since we're only using basic API components from these packages? E.g.`pyvista` downstream is more likely to have issues with this and has it pinned for tests