### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -191,20 +191,20 @@ jobs:
       name: pypi
       url: https://pypi.org/p/pytest-pyvista
     permissions:
-      id-token: write  # this permission is mandatory for trusted publishing
-      contents: write  # required to create a release
+      id-token: write # this permission is mandatory for trusted publishing
+      contents: write # required to create a release
     steps:
-    - uses: actions/download-artifact@v7
-      with:
-        path: dist
-        merge-multiple: true
-    - run: ls -alR dist/
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        generate_release_notes: true
-        files: |
-          ./**/*.whl
-          ./**/*.tar.gz
+      - uses: actions/download-artifact@v7
+        with:
+          path: dist
+          merge-multiple: true
+      - run: ls -alR dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            ./**/*.whl
+            ./**/*.tar.gz


### PR DESCRIPTION
Use trusted publishing to upload to pypi.