### PR TITLE
Minimum python version not fullfilled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]
 name = "pytest_pyvista"
-python_requires = ">=3.10"
 readme = "README.rst"
+requires-python = ">=3.10"
 
 [project.urls]
 Home = "https://github.com/pyvista/pytest-pyvista"


### PR DESCRIPTION
I was able to install the latest `pytest-pyvista` version with `python < 3.10`, even though `3.10` should be the minimum version since `v0.3.0` thanks to https://github.com/pyvista/pytest-pyvista/pull/230.

<img width="975" height="293" alt="image" src="https://github.com/user-attachments/assets/348e27d3-5fc2-4dc4-bcb1-7f023a3bb712" />


This PR fixes it.
See related pyproject specification https://peps.python.org/pep-0621/#requires-python

<img width="967" height="134" alt="image" src="https://github.com/user-attachments/assets/0d6ba955-f20b-44d9-a06b-447d6af41d8f" />


Should we backport that fix to `0.3.0`, `0.3.1` and `v0.3.2` ? This can impact users since it raises TypeError for `python 3.9`:
```
    _OriginalImageFormats = _AllowedImageFormats | Literal["gif", "vtksz"]
TypeError: unsupported operand type(s) for |: '_LiteralGenericAlias' and '_LiteralGenericAlias'
```