### PR TITLE
Add VTK resource cleanup and macOS autorelease pool fixtures

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,7 +173,7 @@ jobs:
     name: macOS Unit Testing
     runs-on: macos-latest
     env:
-      PYTEST_CMD: coverage run --parallel-mode --branch --source=pytest_pyvista -m pytest --verbose
+      TOX_FACTOR: py${{matrix.python-version}}
     strategy:
       fail-fast: false
       matrix:
@@ -190,24 +190,17 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
-      - name: Install pytest-pyvista with test dependencies
-        run: pip install .[tests]
-
-      - name: Install playwright
-        run: playwright install chromium
-
-      - name: Software Report
-        run: |
-          python -c "import pytest_pyvista; pytest_pyvista"
-          python -c "import platform; print(f'arch: {platform.machine()}')"
-          python -c "from Foundation import NSAutoreleasePool; print('NSAutoreleasePool: OK')"
-          pip list
+      - name: Install tox
+        run: pip install tox-uv
 
       - name: Unit Testing
-        run: $PYTEST_CMD
+        run: tox run -e ${{env.TOX_FACTOR}}
 
-      - name: Combine coverage
-        run: coverage combine || true
+      - name: Unit Testing with parallel flag
+        run: tox run -e ${{env.TOX_FACTOR}} -- -n2
+
+      - name: Unit Testing without xdist
+        run: tox run -e ${{env.TOX_FACTOR}}-no_xdist
 
   downstream:
     name: Downstream tests

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Install pytest-pyvista with test dependencies
         run: pip install .[tests]
 
+      - name: Install playwright
+        run: playwright install chromium
+
       - name: Software Report
         run: |
           python -c "import pytest_pyvista; pytest_pyvista"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -203,6 +203,43 @@ jobs:
           pip uninstall -y pytest-xdist && \
           $PYTEST_CMD -k test_arguments
 
+  macOS:
+    name: macOS Unit Testing
+    runs-on: macos-latest
+    env:
+      PYTEST_CMD: coverage run --parallel-mode --branch --source=pytest_pyvista -m pytest --verbose
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.12"
+          - python-version: "3.13"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install pytest-pyvista with test dependencies
+        run: pip install .[tests]
+
+      - name: Software Report
+        run: |
+          python -c "import pytest_pyvista; pytest_pyvista"
+          python -c "import platform; print(f'arch: {platform.machine()}')"
+          python -c "from Foundation import NSAutoreleasePool; print('NSAutoreleasePool: OK')"
+          pip list
+
+      - name: Unit Testing
+        run: $PYTEST_CMD
+
+      - name: Combine coverage
+        run: coverage combine || true
+
   downstream:
     name: Downstream tests
     runs-on: ubuntu-22.04-self-hosted # matching pyvista
@@ -251,6 +288,7 @@ jobs:
       - doc
       - Linux
       - Windows
+      - macOS
       - downstream
     runs-on: ubuntu-24.04
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Testing",
 ]
-dependencies = ["pytest>=6.2.0"]
+dependencies = [
+  "pytest>=6.2.0",
+  "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
+]
 dynamic = ["description", "version"]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-  "pytest>=6.2.0",
   "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
+  "pytest>=6.2.0",
 ]
 dynamic = ["description", "version"]
 license = "MIT"

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -1082,9 +1082,24 @@ def verify_image_cache(
 
 
 @pytest.fixture(autouse=True)
-def _pyvista_close_plotters(pytestconfig: pytest.Config) -> Generator[None, None, None]:
-    """Close all plotters and force garbage collection after each test."""
+def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generator[None, None, None]:
+    """
+    Cleanup fixture.
+
+    This teardown fixture serves mutltiple purposes:
+    - closing all plotters,
+    - clearing trame servers registry (to prevent test collision),
+    - forcing garbage collection.
+    """
     yield
+
+    try:
+        from trame.app.core import AVAILABLE_SERVERS  # noqa: PLC0415
+    except ImportError:
+        ...
+    else:
+        AVAILABLE_SERVERS.clear()
+
     if pytestconfig.getini("pyvista_close_all"):
         pyvista.close_all()
         gc.collect()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 from dataclasses import dataclass
 from functools import cached_property
+import gc
 import importlib
 import io
 import json
@@ -332,6 +333,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
     _add_common_cli_and_ini_options()
     _add_unit_test_cli_and_ini_options()
     _add_doc_cli_and_ini_options()
+
+    # VTK resource cleanup options
+    parser.addini(
+        "pyvista_close_all",
+        type="bool",
+        default=True,
+        help="Automatically close all plotters and run gc.collect() after each test (default: True).",
+    )
 
 
 class VerifyImageCache:
@@ -1070,6 +1079,15 @@ def verify_image_cache(
                 "Fixture `verify_image_cache` is used but no images were generated.\n"
                 "Did you forget to call `show` or `plot`, or set `verify_image_cache.allow_useless_fixture=True`?."
             )
+
+
+@pytest.fixture(autouse=True)
+def _pyvista_close_plotters(pytestconfig: pytest.Config) -> Generator[None, None, None]:
+    """Close all plotters and force garbage collection after each test."""
+    yield
+    if pytestconfig.getini("pyvista_close_all"):
+        pyvista.close_all()
+        gc.collect()
 
 
 def _combine_temp_jsons(json_dir: Path, prefix: str = "") -> set[str]:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -1092,16 +1092,14 @@ def _pyvista_close_plotters(pytestconfig: pytest.Config) -> Generator[None, None
 
 _APPLE_SILICON = sys.platform == "darwin" and platform.machine() == "arm64"
 
+if _APPLE_SILICON:
+    from Foundation import NSAutoreleasePool
+
 
 @pytest.fixture(autouse=True)
 def _pyvista_macos_autorelease() -> Generator[None, None, None]:
     """Drain the Cocoa autorelease pool between tests on macOS Apple Silicon."""
     if not _APPLE_SILICON:
-        yield
-        return
-    try:
-        from Foundation import NSAutoreleasePool  # noqa: PLC0415
-    except ImportError:
         yield
         return
     pool = NSAutoreleasePool.alloc().init()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -1090,6 +1090,25 @@ def _pyvista_close_plotters(pytestconfig: pytest.Config) -> Generator[None, None
         gc.collect()
 
 
+_APPLE_SILICON = sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+@pytest.fixture(autouse=True)
+def _pyvista_macos_autorelease() -> Generator[None, None, None]:
+    """Drain the Cocoa autorelease pool between tests on macOS Apple Silicon."""
+    if not _APPLE_SILICON:
+        yield
+        return
+    try:
+        from Foundation import NSAutoreleasePool  # noqa: PLC0415
+    except ImportError:
+        yield
+        return
+    pool = NSAutoreleasePool.alloc().init()
+    yield
+    del pool
+
+
 def _combine_temp_jsons(json_dir: Path, prefix: str = "") -> set[str]:
     # Read all JSON files from a directory and combine into single set
     combined_data: set[str] = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,8 @@ if TYPE_CHECKING:
 pytest_plugins = "pytester"
 
 
-@pytest.fixture(autouse=True)
-def close_all_plotters() -> Generator[None]:
-    """Close all."""
-    yield
-    pv.close_all()
+# NOTE: close_all_plotters is no longer needed here because the plugin
+# provides the _pyvista_close_plotters autouse fixture (pv.close_all + gc.collect).
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ pytest_plugins = "pytester"
 
 
 # NOTE: close_all_plotters is no longer needed here because the plugin
-# provides the _pyvista_close_plotters autouse fixture (pv.close_all + gc.collect).
+# provides the _close_plotters_clear_trame_servers autouse fixture (pv.close_all + gc.collect).
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1436,7 +1436,7 @@ def test_macos_autorelease_fixture_registered(pytester: pytest.Pytester) -> None
 
         def test_plotter_creates_and_closes():
             # This test just verifies the fixture doesn't interfere.
-            # On macOS ARM64 with pyobjc, it drains the autorelease pool.
+            # On macOS ARM64 it drains the autorelease pool.
             # Everywhere else, it's a no-op.
             pl = pv.Plotter()
             pl.add_mesh(pv.Sphere())

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1396,6 +1396,24 @@ def test_close_all_runs_by_default(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=2)
 
 
+def test_clear_trame_servers(pytester: pytest.Pytester) -> None:
+    """Test the trame servers registry is cleared after each test."""
+    pytester.makepyfile(
+        """
+        from trame.app.core import AVAILABLE_SERVERS, Server
+        from trame.app import get_server
+
+        def test_get_server():
+            assert isinstance(get_server("name"), Server)
+
+        def test_get_server_cleared():
+            assert len(AVAILABLE_SERVERS) == 0
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=2)
+
+
 def test_close_all_can_be_disabled(pytester: pytest.Pytester) -> None:
     """Setting pyvista_close_all = false should skip cleanup."""
     pytester.makeini(

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1370,3 +1370,57 @@ def test_max_image_size(pytester: pytest.Pytester, doc_mode, original_size, max_
     generated_image = pv.read(gen_file)
     expected_size = _get_thumbnail_size(original_size, max_image_size)
     assert generated_image.dimensions == (*expected_size, 1)
+
+
+def test_close_all_runs_by_default(pytester: pytest.Pytester) -> None:
+    """The _pyvista_close_plotters fixture should close plotters after each test."""
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        from pyvista.plotting.plotter import _ALL_PLOTTERS
+
+        pv.OFF_SCREEN = True
+
+        def test_plotter_is_open():
+            pl = pv.Plotter()
+            pl.add_mesh(pv.Sphere())
+            assert len(_ALL_PLOTTERS) > 0
+
+        def test_plotter_was_cleaned_up():
+            # After the previous test, _pyvista_close_plotters should have
+            # called pv.close_all(), so no plotters should remain.
+            assert len(_ALL_PLOTTERS) == 0
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=2)
+
+
+def test_close_all_can_be_disabled(pytester: pytest.Pytester) -> None:
+    """Setting pyvista_close_all = false should skip cleanup."""
+    pytester.makeini(
+        """
+        [pytest]
+        pyvista_close_all = false
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        from pyvista.plotting.plotter import _ALL_PLOTTERS
+
+        pv.OFF_SCREEN = True
+
+        def test_plotter_is_open():
+            pl = pv.Plotter()
+            pl.add_mesh(pv.Sphere())
+            assert len(_ALL_PLOTTERS) > 0
+
+        def test_plotter_still_open():
+            # With cleanup disabled, the plotter from the previous test
+            # should still be in the registry.
+            assert len(_ALL_PLOTTERS) > 0
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=2)

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1424,3 +1424,41 @@ def test_close_all_can_be_disabled(pytester: pytest.Pytester) -> None:
     )
     result = pytester.runpytest("-v")
     result.assert_outcomes(passed=2)
+
+
+def test_macos_autorelease_fixture_registered(pytester: pytest.Pytester) -> None:
+    """The _pyvista_macos_autorelease fixture should be available and not crash."""
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+
+        pv.OFF_SCREEN = True
+
+        def test_plotter_creates_and_closes():
+            # This test just verifies the fixture doesn't interfere.
+            # On macOS ARM64 with pyobjc, it drains the autorelease pool.
+            # Everywhere else, it's a no-op.
+            pl = pv.Plotter()
+            pl.add_mesh(pv.Sphere())
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" and platform.machine() == "arm64"),
+    reason="NSAutoreleasePool only available on macOS ARM64",
+)
+def test_macos_autorelease_pool_drains() -> None:
+    """On macOS ARM64, verify NSAutoreleasePool is importable and the fixture pattern works."""
+    from Foundation import NSAutoreleasePool  # noqa: PLC0415
+
+    pool = NSAutoreleasePool.alloc().init()
+    # Create a plotter to generate Cocoa objects
+    pl = pv.Plotter(off_screen=True)
+    pl.add_mesh(pv.Sphere())
+    pl.render()
+    pl.close()
+    # Draining the pool should not crash
+    del pool


### PR DESCRIPTION
Closes #272, closes #273

- Add `_pyvista_close_plotters` autouse fixture that calls `pv.close_all()` + `gc.collect()` after each test. This prevents VTK render window accumulation, X11 connection exhaustion (Linux), Cocoa autorelease pool overflow (macOS), and dangling OpenGL context segfaults under pytest-xdist.
- Add `pyvista_close_all` INI option (default: `true`) to disable the cleanup fixture for projects that need custom cleanup.
- Add `_pyvista_macos_autorelease` autouse fixture that drains the Cocoa `NSAutoreleasePool` between tests. VTK's `vtkCocoaRenderWindow` creates Objective-C objects that accumulate without draining, capping out around 500 render windows per process before SIGBUS. No-op on non-macOS, non-ARM64, and when `pyobjc` is not installed.
- Remove the hand-rolled `close_all_plotters` fixture from the test conftest since the plugin now provides it.
