### PR TITLE
Add codecov settings

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,22 @@
+comment:
+  layout: "diff"
+  behavior: default
+
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: 90%
+        threshold: 0%
+        # advanced
+        if_not_found: success
+        if_ci_failed: error
+        if_no_uploads: error
+    patch:
+      default:
+        # basic
+        target: 90%
+        if_not_found: success
+        if_ci_failed: error
+        if_no_uploads: error


### PR DESCRIPTION
Add `codecov` settings (copy-paste from `pyvista`)

> To be fair the codecov comment gave misleading checkmarks of approval ✅. I think project settings are the problem for not enforcing this and making coverage thresholds a requirement.
> 
> We lost coverage before too: https://github.com/pyvista/pytest-pyvista/pull/196#issuecomment-3239601310
> 
> Which I believe was fixed by https://github.com/pyvista/pytest-pyvista/pull/202. Might be helpful for fixing the issue here too.
> 
> _Originally posted by @user27182 in https://github.com/pyvista/pytest-pyvista/issues/271#issuecomment-4136237998_
            