### PR TITLE
Rename doc-mode failed-image subdirectory from `from_build/` to `from_test/`

### DIFF
--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -494,7 +494,7 @@ def _save_failed_test_image(source_path: Path, category: Literal["warnings", "er
         dest_relative_dir = Path("from_cache") / rel.parent
     else:
         rel = source_path.relative_to(_DocVerifyImageCache.generated_image_dir)
-        dest_relative_dir = Path("from_build") / rel.parent
+        dest_relative_dir = Path("from_test") / rel.parent
 
     dest_dir = _DocVerifyImageCache.failed_image_dir / category / dest_relative_dir
     dest_dir.mkdir(exist_ok=True, parents=True)

--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -166,7 +166,7 @@ def test_both_images_exist(  # noqa: PLR0913
     if (path := Path(failed)).is_dir():
         assert os.listdir(path) == ["errors"]  # noqa: PTH208
         errors_dir = path / "errors"
-        expected_from = "from_build" if missing == "cache" else "from_cache"
+        expected_from = "from_test" if missing == "cache" else "from_cache"
         assert os.listdir(errors_dir) == [expected_from]  # noqa: PTH208
         from_dir = errors_dir / expected_from
         expected_image = from_dir / Path(name).stem / f"{_EnvInfo()}.{image_format}" if generate_subdirs and missing == "cache" else from_dir / name
@@ -230,10 +230,10 @@ def test_compare_images_warning(pytester: pytest.Pytester, *, failed_image_dir: 
         assert from_cache_file.is_file()
         assert not file_has_changed(str(from_cache_file), str(original))
 
-        from_build = Path(failed) / "warnings" / "from_build"
-        from_build_file = from_build / Path(name).stem / f"{_EnvInfo()}.{image_format}" if generate_subdirs else from_build / name
-        assert from_build_file.is_file()
-        assert file_has_changed(str(from_build_file), str(from_cache_file))
+        from_test = Path(failed) / "warnings" / "from_test"
+        from_test_file = from_test / Path(name).stem / f"{_EnvInfo()}.{image_format}" if generate_subdirs else from_test / name
+        assert from_test_file.is_file()
+        assert file_has_changed(str(from_test_file), str(from_cache_file))
 
     result.stdout.re_match_lines(
         [rf".*UserWarning: {Path(name).stem} Exceeded image regression warning of 200\.0 with an image error of [0-9]+\.[0-9]+"]
@@ -295,10 +295,10 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
         if failed_image_dir:
             assert not file_has_changed(str(from_cache), str(blue_filename))
 
-        from_build = Path(failed, "errors_as_warnings", "from_build", build_filename.name)
-        assert from_build.is_file() == failed_image_dir
+        from_test = Path(failed, "errors_as_warnings", "from_test", build_filename.name)
+        assert from_test.is_file() == failed_image_dir
         if failed_image_dir:
-            assert file_has_changed(str(from_build), str(from_cache))
+            assert file_has_changed(str(from_test), str(from_cache))
 
     else:  # 'green'
         # Comparison with all cached images fails
@@ -318,10 +318,10 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
             if failed_image_dir:
                 assert not file_has_changed(str(from_cache), str(filename))
 
-        from_build = Path(failed, "errors", "from_build", build_filename.name)
-        assert from_build.is_file() == failed_image_dir
+        from_test = Path(failed, "errors", "from_test", build_filename.name)
+        assert from_test.is_file() == failed_image_dir
         if failed_image_dir:
-            assert file_has_changed(str(from_build), str(from_cache))
+            assert file_has_changed(str(from_test), str(from_cache))
 
 
 @pytest.mark.parametrize("include_vtksz", [True, False])
@@ -523,7 +523,7 @@ def test_customizing_tests(pytester: pytest.Pytester) -> None:
     assert expected_file.is_file()
 
     assert Path(failed).is_dir()
-    expected_file = Path(failed) / "errors" / "from_build" / expected_relpath
+    expected_file = Path(failed) / "errors" / "from_test" / expected_relpath
     assert expected_file.is_file()
 
 
@@ -619,7 +619,7 @@ def test_include_vtksz(pytester: pytest.Pytester, include_vtksz, max_image_size)
     assert actual_max_size == expected_max_size
 
     assert Path(failed).is_dir()
-    expected_file = Path(failed) / "errors" / "from_build" / name_generated
+    expected_file = Path(failed) / "errors" / "from_test" / name_generated
     assert expected_file.is_file()
 
 


### PR DESCRIPTION
Rename the doc-mode failed-image subdirectory from `from_build/` to `from_test/` so it matches the regular (non-doc) test mode convention.

`pytest_pyvista` saves failed test images under `<failed_image_dir>/<category>/<from_X>/...`, but the two modes disagreed on the `<from_X>` name:

- Regular test mode (`pytest_pyvista.py`) writes to `from_test/` (paired with `from_cache/`).
- Doc mode (`doc_mode.py`) writes to `from_build/` (paired with `from_cache/`).

The inconsistency broke pyvista's Doc Image Report workflow (see https://github.com/pyvista/pyvista/actions/runs/24313612973/job/70989822743?pr=8498). The report generator added in https://github.com/pyvista/pyvista/pull/8451 and implemented for docs tests in https://github.com/pyvista/pyvista/pull/8476 looks for `from_test/` subdirs, so when it scanned the `doc-failed-test-images` artifact it found no matching categories, returned an empty result, logged `No image differences found. Skipping report generation.`, and the upload + commit-status steps were skipped, even though the artifact contained 331 real diffs (2 errors, 4 errors-as-warnings, 325 warnings).

The pyvista-side report generator was written against the regular-test-mode convention, so aligning doc mode to `from_test/` is the consistent fix and unblocks the report upload without changing the generator.

I figured making these directory names consistent was a better choice that having banching logic downstream for this
