### PR TITLE
Disable PyVista SMP tools during test sessions for determinism

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -490,6 +490,17 @@ Or, set them to different values:
     generate_subdirs = true
     doc_generate_subdirs = false
 
+By default, a session-scoped autouse fixture disables PyVista SMP
+(shared-memory parallel) tools during the test session by forcing the
+sequential SMP backend with a single thread. This makes filters that rely
+on shared-memory parallelism behave deterministically and reproducibly
+across runs. To opt out and leave the SMP backend untouched:
+
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    pyvista_disable_smp = false
+
 Contributing
 ------------
 Contributions are always welcome. Tests can be run with `tox`_, please ensure

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -342,6 +342,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
         help="Automatically close all plotters and run gc.collect() after each test (default: True).",
     )
 
+    parser.addini(
+        "pyvista_disable_smp",
+        type="bool",
+        default=True,
+        help=("Disable PyVista SMP (shared-memory parallel) tools during the test session for deterministic, reproducible runs (default: True)."),
+    )
+
 
 class VerifyImageCache:
     """
@@ -1103,6 +1110,24 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
     if pytestconfig.getini("pyvista_close_all"):
         pyvista.close_all()
         gc.collect()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _disable_smp_in_tests(pytestconfig: pytest.Config) -> None:
+    """
+    Disable PyVista SMP tools for deterministic, reproducible test runs.
+
+    Forces the sequential SMP backend with a single thread so that
+    filters relying on shared-memory parallelism behave deterministically
+    across runs. Gated by the ``pyvista_disable_smp`` ini option (default
+    ``True``) so downstream projects can opt out. This is a graceful no-op
+    on versions of pyvista that predate the ``enable_smp_tools`` API.
+    """
+    if not pytestconfig.getini("pyvista_disable_smp"):
+        return
+
+    with contextlib.suppress(AttributeError):
+        pyvista.enable_smp_tools(backend="sequential", n_threads=1)
 
 
 _APPLE_SILICON = sys.platform == "darwin" and platform.machine() == "arm64"

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1480,3 +1480,87 @@ def test_macos_autorelease_pool_drains() -> None:
     pl.close()
     # Draining the pool should not crash
     del pool
+
+
+def test_disable_smp_in_tests_sequential_single_thread(pytester: pytest.Pytester) -> None:
+    """The autouse fixture forces a sequential, single-threaded SMP backend."""
+    pytester.makepyfile(
+        """
+        import pyvista
+        from pyvista import _vtk
+
+
+        def test_smp_backend_is_sequential():
+            assert _vtk.vtkSMPTools.GetBackend() == "Sequential"
+            assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 1
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_disable_smp_opt_out_is_noop(pytester: pytest.Pytester) -> None:
+    """With ``pyvista_disable_smp = false`` the fixture does not call enable_smp_tools."""
+    pytester.makeini(
+        """
+        [pytest]
+        pyvista_disable_smp = false
+        """
+    )
+    # Install the spy at conftest import time, which is guaranteed to happen
+    # before any session-scoped fixture (including the plugin's) runs.
+    pytester.makeconftest(
+        """
+        import pyvista
+
+        _original = pyvista.enable_smp_tools
+
+
+        def _spy(*args, **kwargs):
+            with open("smp_calls.log", "a") as fh:
+                fh.write(repr((args, kwargs)) + "\\n")
+            return _original(*args, **kwargs)
+
+
+        pyvista.enable_smp_tools = _spy
+        """
+    )
+    pytester.makepyfile(
+        """
+        import os
+
+
+        def test_enable_smp_tools_not_called():
+            assert not os.path.exists("smp_calls.log")
+        """
+    )
+    # Run out-of-process so the conftest monkeypatch cannot leak into this
+    # worker's pyvista module.
+    result = pytester.runpytest_subprocess()
+    result.assert_outcomes(passed=1)
+    assert not (pytester.path / "smp_calls.log").exists()
+
+
+def test_disable_smp_version_guard_old_pyvista(pytester: pytest.Pytester) -> None:
+    """Simulating old pyvista (no enable_smp_tools) is a graceful no-op, not an error."""
+    pytester.makeconftest(
+        """
+        import pyvista
+
+        # Simulate a pyvista release that predates the enable_smp_tools API.
+        del pyvista.enable_smp_tools
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pyvista
+
+
+        def test_no_enable_smp_tools_attr():
+            assert not hasattr(pyvista, "enable_smp_tools")
+        """
+    )
+    # Run out-of-process so deleting the attribute cannot leak into this
+    # worker's pyvista module.
+    result = pytester.runpytest_subprocess()
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Parallel SMP can reorder floating-point reductions and perturb image regression results between runs. This adds a session-scoped autouse fixture that pins PyVista to the sequential single-thread SMP backend so renders are reproducible.

Default on, opt out with `pyvista_disable_smp = false`. Graceful no-op on versions of PyVista that predate `enable_smp_tools`.

resolves #288