### PR TITLE
Enable faulthandler and force OFF_SCREEN by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,17 @@ the ``verify_image_cache`` fixture should be used for each test for image compar
         pl.show()
 
 
+When the plugin is loaded it also enables ``faulthandler`` so a Python traceback
+is dumped if VTK triggers a fatal error such as a segmentation fault, and it sets
+``pyvista.OFF_SCREEN = True`` so headless test runs never pop up a window. To leave
+``OFF_SCREEN`` untouched, set the ``pyvista_off_screen`` ini option to ``false``:
+
+.. code-block:: ini
+
+    [pytest]
+    pyvista_off_screen = false
+
+
 If most tests utilize this functionality, possibly restricted to a module,
 a wrapped version could be used
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
+import faulthandler
 from functools import cached_property
 import gc
 import importlib
@@ -37,6 +38,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
 
     import xdist.workermanage
+
+# Dump a Python traceback on fatal errors such as SIGSEGV or SIGBUS from VTK.
+faulthandler.enable()
 
 VISITED_CACHED_IMAGE_NAMES: set[str] = set()
 SKIPPED_CACHED_IMAGE_NAMES: set[str] = set()
@@ -340,6 +344,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
         type="bool",
         default=True,
         help="Automatically close all plotters and run gc.collect() after each test (default: True).",
+    )
+    parser.addini(
+        "pyvista_off_screen",
+        type="bool",
+        default=True,
+        help="Force pyvista.OFF_SCREEN = True for headless rendering (default: True). Set False to leave OFF_SCREEN untouched.",
     )
 
 
@@ -939,6 +949,10 @@ def _paths_from_strings(strings: list[str]) -> list[Path]:
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config) -> None:
     """Configure pytest session."""
+    # Force off-screen rendering for headless environments unless opted out
+    if config.getini("pyvista_off_screen"):
+        pyvista.OFF_SCREEN = True
+
     # Validate CLI args
     doc_mode = config.getoption("doc_mode")
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import platform
 import re
 import shutil
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -1480,3 +1481,72 @@ def test_macos_autorelease_pool_drains() -> None:
     pl.close()
     # Draining the pool should not crash
     del pool
+
+
+def test_off_screen_forced_by_default(pytester: pytest.Pytester) -> None:
+    """The plugin flips ``pyvista.OFF_SCREEN`` back to True by default."""
+    # Set OFF_SCREEN = False at import time, before the plugin's
+    # pytest_configure runs. The plugin must force it back to True.
+    pytester.makeconftest(
+        """
+        import pyvista
+
+        pyvista.OFF_SCREEN = False
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pyvista
+
+
+        def test_off_screen_is_true():
+            assert pyvista.OFF_SCREEN is True
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_off_screen_not_forced_when_ini_false(pytester: pytest.Pytester) -> None:
+    """Setting ``pyvista_off_screen = false`` leaves ``OFF_SCREEN`` untouched."""
+    pytester.makeini(
+        """
+        [pytest]
+        pyvista_off_screen = false
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pyvista
+
+        # Start from a known False state; the plugin must not flip it to True.
+        pyvista.OFF_SCREEN = False
+
+
+        def test_off_screen_unchanged():
+            assert pyvista.OFF_SCREEN is False
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_faulthandler_enabled_after_plugin_load() -> None:
+    """Importing the plugin module enables ``faulthandler``."""
+    # Run in a fresh subprocess so the result cannot be tainted by faulthandler
+    # being enabled elsewhere in this process. Disable it first, prove it is
+    # off, then assert importing the plugin module turns it back on.
+    script = (
+        "import faulthandler\n"
+        "faulthandler.disable()\n"
+        "assert faulthandler.is_enabled() is False\n"
+        "import pytest_pyvista.pytest_pyvista  # noqa: F401\n"
+        "assert faulthandler.is_enabled() is True\n"
+    )
+    result = subprocess.run(  # noqa: S603  # fixed literal command, no untrusted input
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Every downstream PyVista project sets `faulthandler.enable()` and `pyvista.OFF_SCREEN = True` on its own, and the ones that forget get opaque segfaults or hanging headless CI. The plugin now does both: faulthandler is enabled when the plugin is imported, and `OFF_SCREEN` is forced during configuration.

Behavior change: a project that intentionally runs on-screen under pytest must set `pyvista_off_screen = false`. faulthandler is enabled unconditionally at import with no opt-out.

resolves #276