### PR TITLE
Compare best-match cached baseline first for multi-cache tests

### DIFF
--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -498,7 +498,9 @@ class VerifyImageCache:
         image_filename = Path(self.cache_dir, image_name)
         image_dirname = Path(self.cache_dir, Path(image_name).stem)
 
-        cached_image_paths = _get_file_paths(image_dirname, ext=self.image_format) if image_dirname.is_dir() else [image_filename]
+        cached_image_paths = (
+            _get_file_paths(image_dirname, ext=self.image_format, env_info=self.env_info) if image_dirname.is_dir() else [image_filename]
+        )
         if not cached_image_paths:
             # Path is an empty dir, append default expected image path
             cached_image_paths.append(image_dirname / f"{self.env_info}.{self.image_format}")
@@ -647,9 +649,134 @@ def _get_generated_image_path(parent: Path, image_name: Path | str, *, generate_
     return generated_image_path.resolve()
 
 
-def _get_file_paths(dir_: Path, ext: str) -> list[Path]:
-    """Get all paths of files with a specific extension inside a directory tree."""
-    return sorted(dir_.rglob(f"*.{ext}"))
+_IMAGE_CACHE_OS_ALIASES: dict[str, tuple[str, ...]] = {
+    "darwin": ("darwin", "macos"),
+    "linux": ("linux",),
+    "windows": ("windows",),
+}
+_KNOWN_IMAGE_CACHE_OS_TOKENS = frozenset(token for tokens in _IMAGE_CACHE_OS_ALIASES.values() for token in tokens)
+
+
+def _parse_cached_vtk_version(path: Path) -> tuple[int, int] | None:
+    """
+    Parse a ``vtk-<major>.<minor>`` version from a cached image filename.
+
+    Parameters
+    ----------
+    path : Path
+        Path to a cached image. Only the file stem is inspected.
+
+    Returns
+    -------
+    tuple[int, int] or None
+        The ``(major, minor)`` VTK version encoded in the filename, or
+        ``None`` when no recognizable version token is present.
+
+    """
+    # Anchor ``vtk`` at a field boundary (start of stem or after a ``-``,
+    # ``_`` or ``.`` separator) and require the version to end at a field
+    # boundary, so ``myvtk-1.2`` or ``vtk-9.x`` do not parse.
+    match = re.search(r"(?:^|[-._])vtk-(\d+)\.(\d+)(?:[-._]|$)", path.stem.lower())
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _cached_image_sort_key(path: Path, env_info: _EnvInfo) -> tuple[int, int, int, int, str]:
+    """
+    Compute a sort key ranking a cached image by environment match.
+
+    Lower keys sort first, so the candidate that best matches the current
+    environment is compared before others. Ranking is, in order: exact full
+    environment-string match, environment-string substring match,
+    current-OS match (with ``darwin``/``macos`` aliasing), exact VTK
+    major.minor match then nearest VTK version by distance, and finally the
+    POSIX path for a stable fallback. Any unparsable filename never raises
+    and simply sorts toward the end.
+
+    Parameters
+    ----------
+    path : Path
+        Path to a cached image candidate.
+
+    env_info : _EnvInfo
+        Environment descriptor for the current run, used to build the
+        expected environment string.
+
+    Returns
+    -------
+    tuple[int, int, int, int, str]
+        The composite sort key ``(env_rank, os_rank, vtk_rank,
+        vtk_distance, posix_path)``.
+
+    """
+    stem = path.stem.lower()
+    env_str = str(env_info).lower()
+
+    if stem == env_str:
+        env_rank = 0
+    elif env_str and env_str in stem:
+        env_rank = 1
+    else:
+        env_rank = 2
+
+    # The OS field is the first token of the stem in the pyvista naming
+    # convention, optionally preceded by a configured ``prefix`` field.
+    # Restricting the match to that leading position is boundary-aware:
+    # ``linux-vtk-9.6`` matches but ``non-linux-foo`` does not.
+    fields = [token for token in re.split(r"[-._]", stem) if token]
+    prefix_token = env_info.prefix.lower()
+    if prefix_token and fields and fields[0] == prefix_token:
+        fields = fields[1:]
+    leading_os_token = fields[0] if fields else None
+
+    system = platform.system().lower()
+    current_os_tokens = _IMAGE_CACHE_OS_ALIASES.get(system, (system,))
+    has_known_os_token = leading_os_token in _KNOWN_IMAGE_CACHE_OS_TOKENS
+    matches_current_os = leading_os_token in current_os_tokens
+    os_rank = 0 if matches_current_os else 1 if not has_known_os_token else 2
+
+    current_vtk_version = tuple(pyvista.vtk_version_info[:2])
+    cached_vtk_version = _parse_cached_vtk_version(path)
+    if cached_vtk_version is None:
+        vtk_rank = 1
+        vtk_distance = 0
+    else:
+        vtk_rank = 0 if cached_vtk_version == current_vtk_version else 2
+        vtk_distance = abs(cached_vtk_version[0] - current_vtk_version[0]) * 100 + abs(cached_vtk_version[1] - current_vtk_version[1])
+
+    return env_rank, os_rank, vtk_rank, vtk_distance, path.as_posix()
+
+
+def _get_file_paths(dir_: Path, ext: str, *, env_info: str | _EnvInfo | None = None) -> list[Path]:
+    """
+    Get all paths of files with a specific extension inside a directory tree.
+
+    Parameters
+    ----------
+    dir_ : Path
+        Directory tree to search recursively.
+
+    ext : str
+        File extension to match, without the leading dot.
+
+    env_info : str or _EnvInfo, optional
+        When an :class:`_EnvInfo` is given, candidates are ordered so the
+        best environment match sorts first (see
+        :func:`_cached_image_sort_key`). When ``None`` or a plain string,
+        the legacy lexicographic ``sorted`` order is preserved for
+        backward compatibility.
+
+    Returns
+    -------
+    list[Path]
+        The matching paths, ordered as described above.
+
+    """
+    paths = sorted(dir_.rglob(f"*.{ext}"))
+    if not isinstance(env_info, _EnvInfo):
+        return paths
+    return sorted(paths, key=lambda path: _cached_image_sort_key(path, env_info))
 
 
 def _compare_images(test_image: Path | str | pyvista.Plotter, cached_image: Path | str) -> float:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -22,8 +22,11 @@ from pytest_pyvista.pytest_pyvista import _DOC_MODE_CLI_ARGS
 from pytest_pyvista.pytest_pyvista import _SYSTEM_PROPERTIES
 from pytest_pyvista.pytest_pyvista import _UNIT_TEST_CLI_ARGS
 from pytest_pyvista.pytest_pyvista import PARSER_GROUP_NAME
+from pytest_pyvista.pytest_pyvista import _cached_image_sort_key
 from pytest_pyvista.pytest_pyvista import _EnvInfo
+from pytest_pyvista.pytest_pyvista import _get_file_paths
 from pytest_pyvista.pytest_pyvista import _get_thumbnail_size
+from pytest_pyvista.pytest_pyvista import _parse_cached_vtk_version
 from pytest_pyvista.pytest_pyvista import _SystemProperties
 from pytest_pyvista.pytest_pyvista import pytest_addoption
 
@@ -1059,6 +1062,147 @@ def test_multiple_cache_images(  # noqa: PLR0913
         assert from_test.is_file() == failed_image_dir
         if failed_image_dir:
             assert file_has_changed(str(from_test), str(from_cache))
+
+
+def test_multi_cache_best_match_no_warning(pytester: pytest.Pytester) -> None:
+    """
+    Regression test for #286.
+
+    A per-test subdir holds OS-specific and VTK-specific baselines. Only the
+    current-OS / current-VTK baseline matches the rendered image. With the
+    best-match ordering fix the correct baseline is compared first, so the
+    test passes silently. Before the fix a non-matching baseline was compared
+    first, failed, then the result was downgraded to a noisy warning.
+    """
+    cache = "cache"
+    subdir = "imcache"
+    cache_parent = pytester.path / cache / subdir
+    system = platform.system()
+    os_token = {"Darwin": "macOS", "Linux": "linux", "Windows": "windows"}.get(system, system.lower())
+    vtk_major, vtk_minor = pv.vtk_version_info[:2]
+
+    # Wrong-OS baseline (blue) sorts before the correct one lexicographically
+    # on macOS ("linux" < "macOS"); a deliberately wrong color guarantees it
+    # fails if compared first.
+    for other_os in ("linux", "macOS", "windows"):
+        if other_os == os_token:
+            continue
+        make_cached_images(cache_parent, subdir, name=f"{other_os}-vtk-{vtk_major}.{vtk_minor}.png", color="blue")
+    # Wrong-VTK baseline for the current OS, also blue.
+    make_cached_images(cache_parent, subdir, name=f"{os_token}-vtk-{vtk_major}.{vtk_minor - 1}.png", color="blue")
+    # The single correct baseline: current OS + current VTK, red.
+    correct = make_cached_images(cache_parent, subdir, name=f"{os_token}-vtk-{vtk_major}.{vtk_minor}.png", color="red")
+    assert correct.is_file()
+
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+        def test_imcache(verify_image_cache):
+            sphere = pv.Sphere()
+            plotter = pv.Plotter()
+            plotter.add_mesh(sphere, color="red")
+            plotter.show()
+        """
+    )
+
+    result = pytester.runpytest("--image_cache_dir", cache)
+    result.assert_outcomes(passed=1, warnings=0)
+    result.stdout.no_re_match_line(r".*This test has multiple cached images.*")
+
+
+def test_cached_image_sort_key_ranks_current_env_first() -> None:
+    """The current-OS + current-VTK baseline must sort before the rest."""
+    env_info = _EnvInfo()
+    system = platform.system()
+    os_token = {"Darwin": "macOS", "Linux": "linux", "Windows": "windows"}.get(system, system.lower())
+    vtk_major, vtk_minor = pv.vtk_version_info[:2]
+
+    correct = Path(f"{os_token}-vtk-{vtk_major}.{vtk_minor}.png")
+    wrong_os = Path(f"otheros-vtk-{vtk_major}.{vtk_minor}.png")
+    no_tokens = Path("totally-unrelated-name.png")
+    paths = [wrong_os, no_tokens, correct]
+
+    ordered = sorted(paths, key=lambda p: _cached_image_sort_key(p, env_info))
+    assert ordered[0] == correct
+    # An unparsable name must not raise and must sort last.
+    assert _cached_image_sort_key(no_tokens, env_info)  # does not raise
+    assert ordered[-1] == no_tokens
+
+
+def test_parse_cached_vtk_version_boundary() -> None:
+    """Version parsing is boundary-aware and never raises."""
+    assert _parse_cached_vtk_version(Path("linux-vtk-9.6.png")) == (9, 6)
+    assert _parse_cached_vtk_version(Path("vtk-9.5.png")) == (9, 5)
+    assert _parse_cached_vtk_version(Path("prefix_macOS-vtk-10.2-extra.png")) == (10, 2)
+    # Malformed or non-boundary tokens must not parse.
+    assert _parse_cached_vtk_version(Path("vtk-9.x.png")) is None
+    assert _parse_cached_vtk_version(Path("vtk-9.png")) is None
+    assert _parse_cached_vtk_version(Path("no-version-token.png")) is None
+    # ``myvtk-1.2`` must not be read as VTK 1.2 after the boundary fix.
+    assert _parse_cached_vtk_version(Path("myvtk-1.2.png")) is None
+
+
+def test_cached_image_sort_key_tie_stability() -> None:
+    """Two filenames with identical rank sort deterministically by posix path."""
+    env_info = _EnvInfo()
+    # Neither carries an OS or VTK token, so every rank component ties and
+    # only ``path.as_posix()`` breaks the tie.
+    a = Path("alpha-unrelated.png")
+    b = Path("beta-unrelated.png")
+    key_a = _cached_image_sort_key(a, env_info)
+    key_b = _cached_image_sort_key(b, env_info)
+    assert key_a[:-1] == key_b[:-1]
+    assert key_a[-1] == "alpha-unrelated.png"
+    assert sorted([b, a], key=lambda p: _cached_image_sort_key(p, env_info)) == [a, b]
+    assert sorted([a, b], key=lambda p: _cached_image_sort_key(p, env_info)) == [a, b]
+
+
+def test_cached_image_sort_key_non_linux_not_os_match() -> None:
+    """A ``non-linux`` filename must not be ranked as an OS match on Linux."""
+    env_info = _EnvInfo()
+    system = platform.system()
+    os_token = {"Darwin": "macOS", "Linux": "linux", "Windows": "windows"}.get(system, system.lower())
+    vtk_major, vtk_minor = pv.vtk_version_info[:2]
+
+    # ``non-<os>-foo`` contains the OS substring but the leading field is
+    # ``non``, so it must rank strictly worse than a real OS baseline.
+    decoy = Path(f"non-{os_token}-foo-vtk-{vtk_major}.{vtk_minor}.png")
+    real = Path(f"{os_token}-vtk-{vtk_major}.{vtk_minor}.png")
+    decoy_key = _cached_image_sort_key(decoy, env_info)
+    real_key = _cached_image_sort_key(real, env_info)
+    # os_rank is index 1 of the key. The decoy carries no leading OS token
+    # so it is "no known OS token" (rank 1), strictly worse than the real
+    # current-OS match (rank 0).
+    assert real_key[1] == 0
+    assert decoy_key[1] == 1
+    assert real_key < decoy_key
+
+
+def test_cached_image_sort_key_vtk_distance_tiebreak() -> None:
+    """The nearer VTK version wins when no OS token is present."""
+    env_info = _EnvInfo()
+    vtk_major, vtk_minor = pv.vtk_version_info[:2]
+    near = Path(f"vtk-{vtk_major}.{vtk_minor}.png")
+    far = Path(f"vtk-{vtk_major}.{vtk_minor - 1}.png")
+
+    ordered = sorted([far, near], key=lambda p: _cached_image_sort_key(p, env_info))
+    assert ordered == [near, far]
+
+
+def test_get_file_paths_backward_compat(tmp_path: Path) -> None:
+    """With ``env_info=None`` (or a str) ordering equals plain ``sorted``."""
+    subdir = tmp_path / "cache"
+    subdir.mkdir()
+    names = ["windows-vtk-9.6.png", "linux-vtk-9.6.png", "macOS-vtk-9.6.png"]
+    for name in names:
+        (subdir / name).write_bytes(b"")
+
+    expected = sorted(subdir.rglob("*.png"))
+    assert _get_file_paths(subdir, "png") == expected
+    assert _get_file_paths(subdir, "png", env_info=None) == expected
+    # A plain string env_info must also fall back to plain sorted order.
+    assert _get_file_paths(subdir, "png", env_info="some-env-string") == expected
 
 
 @pytest.mark.parametrize("on_ci", [True, False], ids=["on_ci", "not_on_ci"])


### PR DESCRIPTION
A test with multiple cached baselines (one per OS or VTK version) compared against the lexicographically first image. On a platform whose baseline sorted later, the first comparison failed and the test passed against the correct image but was downgraded to a noisy warning, even though the cache was correct. PyVista CI was full of these.

Cached candidates are now ranked by environment match (exact env string, current OS with darwin/macos aliasing, then exact and nearest VTK version) before comparison, so the right baseline is checked first and a correctly cached test stays silent. Token matching is boundary-aware so names like `non-linux-foo` or `myvtk-1.2` do not false-match.

Behavior note: for an existing multi-image cache the first compared image changes. It still falls back to every candidate, so pass/fail outcomes are unchanged; only the comparison order and the spurious warnings differ. Single-image caches and the string/None paths keep the previous lexicographic order.

resolves #286