### PR TITLE
Add opt-in blank rendered image detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,6 +344,12 @@ in the beginning of your test function.
   ``verify_image_cache`` fixture is used but no images are generated. The value of this
   flag takes precedence over the global flag by the same name (see above).
 
+* ``allow_blank_image``: When the global ``pyvista_check_blank_images`` option is enabled
+  (see `Configuration`_), every test that renders an essentially blank (near-uniform)
+  image fails, since this usually indicates a broken test that renders nothing yet still
+  passes. Set this flag to ``True`` to bypass the check for a test that intentionally
+  renders a near-blank scene.
+
 * ``env_info``: Dataclass for controlling the environment info used to name the generated
   test image(s) when the ``--generate_dirs`` option is used. The info can be test-specific
   or can be modified globally by wrapping the ``verify_image_cache`` fixture, e.g.:
@@ -489,6 +495,24 @@ Or, set them to different values:
     [tool.pytest.ini_options]
     generate_subdirs = true
     doc_generate_subdirs = false
+
+Detect blank images. This is opt-in and off by default. When enabled, every test
+that renders an essentially blank (near-uniform) image fails, since a test that
+renders nothing usually indicates a silently broken test. The rendered image is
+compared against an empty ``pyvista.Plotter`` of the same window size; if the
+difference is within ``pyvista_blank_image_atol`` the image is treated as blank.
+
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    pyvista_check_blank_images = true
+    pyvista_blank_image_atol = 25.0
+
+Bypass the check for a single test that intentionally renders a near-blank scene by
+setting ``verify_image_cache.allow_blank_image = True`` at the top of that test (see
+``Customizing unit tests``). Note that a legitimately mostly-empty scene, for example
+a small object on a large uniform background, can be flagged as blank. This is why
+the check is opt-in and ``pyvista_blank_image_atol`` is tunable.
 
 Contributing
 ------------

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -47,6 +47,7 @@ PYVISTA_FAILED_IMAGE_CACHE_DIRNAME = "pyvista_failed_image_dir"
 PARSER_GROUP_NAME = "pyvista"
 DEFAULT_ERROR_THRESHOLD: float = 500.0
 DEFAULT_WARNING_THRESHOLD: float = 200.0
+DEFAULT_BLANK_IMAGE_ATOL: float = 25.0
 _DOC_MODE_CLI_ARGS: set[str] = set()
 _UNIT_TEST_CLI_ARGS: set[str] = set()
 
@@ -342,6 +343,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
         help="Automatically close all plotters and run gc.collect() after each test (default: True).",
     )
 
+    # Blank image detection options
+    parser.addini(
+        "pyvista_check_blank_images",
+        type="bool",
+        default=False,
+        help=(
+            "Error if a test renders an essentially blank (near-uniform) image. "
+            "Opt-in, off by default. Bypass per-test with "
+            "``verify_image_cache.allow_blank_image = True`` (default: False)."
+        ),
+    )
+    parser.addini(
+        "pyvista_blank_image_atol",
+        default=str(DEFAULT_BLANK_IMAGE_ATOL),
+        help=(
+            "Absolute tolerance for the blank image check. A rendered image whose "
+            f"difference from a blank reference is <= this value is flagged as blank "
+            f"(default: {DEFAULT_BLANK_IMAGE_ATOL})."
+        ),
+    )
+
 
 class VerifyImageCache:
     """
@@ -406,6 +428,8 @@ class VerifyImageCache:
     add_missing_images = False
     reset_only_failed = False
     generate_subdirs: bool = False
+    check_blank_images: bool = False
+    blank_image_atol: float = DEFAULT_BLANK_IMAGE_ATOL
     image_format: _AllowedImageFormats
     max_image_size: int | None
 
@@ -446,6 +470,7 @@ class VerifyImageCache:
         self.macos_skip_image_cache = False
 
         self.skip = False
+        self.allow_blank_image = False
         self.n_calls = 0
 
     @staticmethod
@@ -494,6 +519,14 @@ class VerifyImageCache:
             return
 
         VISITED_CACHED_IMAGE_NAMES.add(image_name)
+
+        if self.check_blank_images and not self.allow_blank_image:
+            blank_msg = _check_blank_image(plotter, atol=self.blank_image_atol)
+            if blank_msg:
+                if self.failed_image_dir is not None:
+                    self._save_failed_test_images("error", plotter, image_name)
+                remove_plotter_close_callback()
+                raise RegressionError(blank_msg)
 
         image_filename = Path(self.cache_dir, image_name)
         image_dirname = Path(self.cache_dir, Path(image_name).stem)
@@ -652,8 +685,8 @@ def _get_file_paths(dir_: Path, ext: str) -> list[Path]:
     return sorted(dir_.rglob(f"*.{ext}"))
 
 
-def _compare_images(test_image: Path | str | pyvista.Plotter, cached_image: Path | str) -> float:
-    if isinstance(test_image, pyvista.Plotter) and Path(cached_image).suffix == ".jpg":
+def _compare_images(test_image: Path | str | pyvista.Plotter, cached_image: Path | str | np.ndarray) -> float:
+    if isinstance(test_image, pyvista.Plotter) and not isinstance(cached_image, np.ndarray) and Path(cached_image).suffix == ".jpg":
         # Need to process image to apply jpg compression
 
         # Get screenshot as a PIL image
@@ -671,7 +704,49 @@ def _compare_images(test_image: Path | str | pyvista.Plotter, cached_image: Path
         return pyvista.compare_images(arr_jpg, str(cached_image))
     # Cast Path to str
     test_img = test_image if isinstance(test_image, pyvista.Plotter) else str(test_image)
-    return pyvista.compare_images(test_img, str(cached_image))
+    cached = cached_image if isinstance(cached_image, np.ndarray) else str(cached_image)
+    return pyvista.compare_images(test_img, cached)
+
+
+def _check_blank_image(plotter: pyvista.Plotter, atol: float) -> str | None:
+    """
+    Detect whether a plotter rendered an essentially blank image.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        The plotter whose rendered image is checked for blankness.
+
+    atol : float
+        Tolerance. A difference from a blank reference ``<= atol`` is blank.
+
+    Returns
+    -------
+    str or None
+        An error message when the image is blank, otherwise ``None``.
+
+    """
+    window_size = cast("tuple[int, int]", tuple(plotter.window_size))
+    blank = pyvista.Plotter(off_screen=True, window_size=list(window_size))
+    try:
+        # Use ``screenshot`` directly rather than ``show``. The ``verify_image_cache``
+        # fixture monkeypatches ``Plotter.show`` to inject its callback, so calling
+        # ``show`` here would re-enter this check and recurse infinitely.
+        blank_image = _screenshot(blank, return_img=True, max_image_size=VerifyImageCache.max_image_size)
+        error = _compare_images(plotter, np.asarray(blank_image))
+    finally:
+        blank.close()
+
+    if error <= atol:
+        return (
+            f"Rendered image is essentially blank: its difference from an empty "
+            f"plotter ({error}) is within the blank image tolerance of {atol}. "
+            f"A test that renders nothing usually indicates a broken test. "
+            f"If this is intentional, set "
+            f"`verify_image_cache.allow_blank_image = True` for this test, or "
+            f"tune `pyvista_blank_image_atol`."
+        )
+    return None
 
 
 def _get_thumbnail_size(current_size: tuple[int, int], max_image_size: int) -> tuple[int, int]:
@@ -953,6 +1028,13 @@ def pytest_configure(config: pytest.Config) -> None:
                 msg = f"argument {arg} can only be used with --doc_mode enabled"
                 raise pytest.UsageError(msg)
 
+    blank_atol = config.getini("pyvista_blank_image_atol")
+    try:
+        float(blank_atol)
+    except (TypeError, ValueError):
+        msg = f"Invalid value for `pyvista_blank_image_atol`: {blank_atol!r}. Expected a number (for example {DEFAULT_BLANK_IMAGE_ATOL})."
+        raise pytest.UsageError(msg) from None
+
     is_master = _is_master(config)
     disallow_unused_cache = config.getoption("disallow_unused_cache")
     if is_master and disallow_unused_cache:
@@ -1019,6 +1101,8 @@ def verify_image_cache(
     VerifyImageCache.add_missing_images = pytestconfig.getoption("add_missing_images")
     VerifyImageCache.reset_only_failed = pytestconfig.getoption("reset_only_failed")
     VerifyImageCache.generate_subdirs = pytestconfig.getoption("generate_subdirs")
+    VerifyImageCache.check_blank_images = pytestconfig.getini("pyvista_check_blank_images")
+    VerifyImageCache.blank_image_atol = float(pytestconfig.getini("pyvista_blank_image_atol"))
     VerifyImageCache.image_format = cast("_AllowedImageFormats", _get_option_from_config_or_ini(pytestconfig, "image_format"))
     VerifyImageCache.max_image_size = cast("int | None", _get_option_from_config_or_ini(pytestconfig, "max_image_size"))
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1480,3 +1480,208 @@ def test_macos_autorelease_pool_drains() -> None:
     pl.close()
     # Draining the pool should not crash
     del pool
+
+
+def test_blank_image_check_fails_on_blank_plotter(pytester: pytest.Pytester) -> None:
+    """A blank plotter fails when the blank image check is enabled."""
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_blank(verify_image_cache):
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("*Rendered image is essentially blank*")
+
+
+def test_blank_image_check_passes_on_normal_plot(pytester: pytest.Pytester) -> None:
+    """A normal plot is not flagged as blank when the check is enabled."""
+    make_cached_images(pytester.path)
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_imcache(verify_image_cache):
+            pl = pv.Plotter()
+            pl.add_mesh(pv.Sphere(), color="red")
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_blank_image_check_per_test_bypass(pytester: pytest.Pytester) -> None:
+    """
+    An actually blank plot passes when the per-test bypass is set.
+
+    This isolates the ``allow_blank_image`` guard: the rendered image is genuinely
+    blank, so the check would fail without the bypass. The test must fail if the
+    ``and not self.allow_blank_image`` guard is removed.
+    """
+    # Cache a blank reference so the normal image comparison passes; only the
+    # blank check (bypassed here) should be exercised.
+    d = Path(pytester.path, "image_cache_dir")
+    d.mkdir(exist_ok=True, parents=True)
+    pv.Plotter(off_screen=True).screenshot(d / "imcache.png")
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_imcache(verify_image_cache):
+            verify_image_cache.allow_blank_image = True
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+    assert "essentially blank" not in result.stdout.str()
+
+
+def test_blank_image_check_disabled_by_default(pytester: pytest.Pytester) -> None:
+    """A blank plot does not trigger the blank error when the option is absent."""
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_imcache(verify_image_cache):
+            verify_image_cache.skip = True
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+    assert "essentially blank" not in result.stdout.str()
+
+
+@pytest.mark.parametrize(
+    ("atol", "should_fail"),
+    [
+        # A blank plotter compared against a blank reference yields error == 0.0,
+        # so the ``error <= atol`` boundary flips deterministically around 0.0.
+        # This pins the comparison direction: an off-by-one mutation (`<` vs `<=`,
+        # `>` vs `>=`) changes at least one of these outcomes.
+        (-1.0, False),  # atol below 0.0: 0.0 <= -1.0 is False -> pass
+        (0.0, True),  # atol at 0.0: 0.0 <= 0.0 is True -> blank failure
+        (25.0, True),  # atol above 0.0: blank failure
+    ],
+)
+def test_blank_image_atol_boundary(
+    pytester: pytest.Pytester,
+    atol: float,
+    should_fail: bool,  # noqa: FBT001
+) -> None:
+    """Pin the ``error <= atol`` boundary direction for an exactly-blank image."""
+    # Cache a blank reference so the non-blank (pass) case clears the normal
+    # image comparison and only the blank-check boundary is under test.
+    d = Path(pytester.path, "image_cache_dir")
+    d.mkdir(exist_ok=True, parents=True)
+    pv.Plotter(off_screen=True).screenshot(d / "imcache.png")
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_imcache(verify_image_cache):
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        f"""
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        pyvista_blank_image_atol = {atol}
+        """
+    )
+    result = pytester.runpytest()
+    if should_fail:
+        result.assert_outcomes(failed=1)
+        result.stdout.fnmatch_lines("*Rendered image is essentially blank*")
+    else:
+        result.assert_outcomes(passed=1)
+        assert "essentially blank" not in result.stdout.str()
+
+
+def test_blank_image_atol_malformed_raises_usage_error(pytester: pytest.Pytester) -> None:
+    """A non-numeric ``pyvista_blank_image_atol`` is rejected at config time."""
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_blank(verify_image_cache):
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        pyvista_blank_image_atol = "abc"
+        """
+    )
+    result = pytester.runpytest()
+    # A pytest.UsageError aborts before any test runs (no summary line).
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    result.stderr.fnmatch_lines("*Invalid value for `pyvista_blank_image_atol`*")
+
+
+def test_blank_image_check_does_not_recurse(pytester: pytest.Pytester) -> None:
+    """
+    The blank check must not re-enter ``show``.
+
+    ``_check_blank_image`` renders the blank reference via ``_screenshot`` rather
+    than ``blank.show()``. ``show`` is monkeypatched by ``verify_image_cache``, so
+    calling it here would recurse forever. This asserts a clean single failure
+    (not a RecursionError or a hang) for a blank-check-enabled test.
+    """
+    pytester.makepyfile(
+        """
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+
+        def test_blank(verify_image_cache):
+            pl = pv.Plotter()
+            pl.show()
+        """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        pyvista_check_blank_images = true
+        """
+    )
+    result = pytester.runpytest_subprocess(timeout=120)
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("*Rendered image is essentially blank*")
+    assert "RecursionError" not in result.stdout.str()


### PR DESCRIPTION
A test that renders nothing still passes image regression when a matching blank baseline exists, which silently hides a broken test. This adds an optional check that compares the render against an empty plotter of the same window size and errors when the difference is within tolerance.

Off by default. Enable with `pyvista_check_blank_images = true`, tune sensitivity with `pyvista_blank_image_atol`, and bypass a specific test with `verify_image_cache.allow_blank_image = True`. A legitimately sparse scene (a small object on a large uniform background) can trip the check, which is why it is opt-in and the tolerance is configurable.

resolves #238