### PR TITLE
Grade multi-baseline tests against the closest cached image

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -204,7 +204,7 @@ jobs:
 
   downstream:
     name: Downstream tests
-    runs-on: ubuntu-22.04-self-hosted # matching pyvista
+    runs-on: ubuntu-22.04 # matching pyvista
     steps:
       - uses: actions/checkout@v6
 

--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,17 @@ Can be replaced with multiple versions of the image:
    - Use the ``--generate_subdirs`` flag to automatically generate test images in a
      sub-directory format.
 
-When there are multiple images, the test will initially compare the test image
-to the first cached image. If that comparison fails, the test image is then
-compared to all other cached images for that test. The test is successful if one
-of the comparisons is successful, though a warning is still issued if it initially
-failed.
+When there are multiple images, the test image is compared to each of the cached
+images and is graded against the closest match. A warning is only issued if every
+cached image exceeds the warning threshold, and the test only fails if every
+cached image also exceeds the error threshold. A test which closely matches any
+one of its cached images therefore passes silently, regardless of the order in
+which the images are compared.
+
+.. note::
+
+   The comparisons stop as soon as an image is matched within the warning
+   threshold, so a passing test is typically only compared to a single image.
 
 Both use cases (i.e. unit tests and documentation tests) support specifying multiple
 cache images.

--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -24,7 +24,6 @@ from .pytest_pyvista import DEFAULT_WARNING_THRESHOLD
 from .pytest_pyvista import PYVISTA_FAILED_IMAGE_CACHE_DIRNAME
 from .pytest_pyvista import PYVISTA_GENERATED_IMAGE_CACHE_DIRNAME
 from .pytest_pyvista import _AllowedImageFormats
-from .pytest_pyvista import _check_compare_fail
 from .pytest_pyvista import _ensure_dir_exists
 from .pytest_pyvista import _EnvInfo
 from .pytest_pyvista import _get_file_paths
@@ -534,7 +533,6 @@ def test_images(_pytest_pyvista_test_case: _DocVerifyImageCache, doc_verify_imag
     cached_input_is_file = cached_image_path.is_file()
     cached_image_paths = [cached_image_path] if cached_input_is_file else _get_file_paths(cached_image_path, ext=_DocVerifyImageCache.image_format)
     cached_image_paths = cast("list[Path]", cached_image_paths)
-    current_cached_image_path = cached_image_paths[0]
 
     # Ensure test path is an image
     test_image_path = cast("Path", test_case.test_image_path)
@@ -546,28 +544,13 @@ def test_images(_pytest_pyvista_test_case: _DocVerifyImageCache, doc_verify_imag
             test_image_path.rename(new_path)
             test_image_path = new_path
 
-    warn_msg, fail_msg = _test_compare_images(
+    warn_msg, fail_msg, current_cached_image_path = _test_compare_images(
         test_name=test_case.test_name,
         test_image=test_image_path,
-        cached_image=current_cached_image_path,
+        cached_image_paths=cached_image_paths,
         allowed_error=DEFAULT_ERROR_THRESHOLD,
         allowed_warning=DEFAULT_WARNING_THRESHOLD,
     )
-
-    # Try again and compare with other cached images
-    if fail_msg and len(cached_image_paths) > 1:
-        # Compare build image to other known valid versions
-        msg_start = "This test has multiple cached images. It initially failed (as above)"
-        for path in cached_image_paths[1:]:
-            error = pv.compare_images(pv.read(test_image_path), pv.read(path))
-            if _check_compare_fail(test_case.test_name, error, allowed_error=DEFAULT_ERROR_THRESHOLD) is None:
-                # Convert failure into a warning
-                warn_msg = fail_msg + (f"\n{msg_start} but passed when compared to:\n\t{path}")
-                fail_msg = None
-                current_cached_image_path = path
-                break
-        else:  # Loop completed - test still fails
-            fail_msg += f"\n{msg_start} and failed again for all images in:\n\t{_DocVerifyImageCache.image_cache_dir / test_case.test_name!s}"
 
     if fail_msg:
         _save_failed_test_image(test_image_path, "errors")

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -454,7 +454,7 @@ class VerifyImageCache:
         skip_macos = platform.system() == "Darwin" and macos_skip_image_cache
         return skip or ignore_image_cache or skip_windows or skip_macos
 
-    def __call__(self, plotter: Plotter) -> None:  # noqa: C901, PLR0912, PLR0915
+    def __call__(self, plotter: Plotter) -> None:  # noqa: C901, PLR0912
         """
         Either store or validate an image.
 
@@ -530,28 +530,13 @@ class VerifyImageCache:
             return
 
         test_name_no_prefix = test_name.removeprefix("test_")
-        warn_msg, fail_msg = _test_compare_images(
+        warn_msg, fail_msg, current_cached_image = _test_compare_images(
             test_name=test_name_no_prefix,
             test_image=plotter,
-            cached_image=current_cached_image,
+            cached_image_paths=cached_image_paths,
             allowed_error=allowed_error,
             allowed_warning=allowed_warning,
         )
-
-        # Try again and compare with other cached images
-        if fail_msg and len(cached_image_paths) > 1:
-            # Compare test image to other known valid versions
-            msg_start = "This test has multiple cached images. It initially failed (as above)"
-            for path in cached_image_paths[1:]:
-                error = _compare_images(plotter, path)
-                if _check_compare_fail(test_name, error, allowed_error=allowed_error) is None:
-                    # Convert failure into a warning
-                    warn_msg = fail_msg + (f"\n{msg_start} but passed when compared to:\n\t{path}")
-                    fail_msg = None
-                    current_cached_image = path
-                    break
-            else:  # Loop completed - test still fails
-                fail_msg += f"\n{msg_start} and failed again for all images in:\n\t{Path(self.cache_dir, test_name_no_prefix)!s}"
 
         if fail_msg:
             if self.failed_image_dir is not None:
@@ -695,17 +680,49 @@ def _screenshot(plotter: Plotter, *args, max_image_size: int | None, **kwargs) -
 
 
 def _test_compare_images(
-    test_name: str, test_image: Path | str | pyvista.Plotter, cached_image: Path | str, allowed_error: float, allowed_warning: float
-) -> tuple[str | None, str | None]:
-    try:
-        # Check if test should fail or warn
-        error = _compare_images(test_image, cached_image)
-        fail_msg = _check_compare_fail(test_name, error, allowed_error)
-        warn_msg = _check_compare_warn(test_name, error, allowed_warning)
-    except RuntimeError as e:
-        warn_msg = None
-        fail_msg = repr(e)
-    return warn_msg, fail_msg
+    test_name: str, test_image: Path | str | pyvista.Plotter, cached_image_paths: list[Path], allowed_error: float, allowed_warning: float
+) -> tuple[str | None, str | None, Path]:
+    """
+    Compare a test image to all of its cached images and grade it on the closest match.
+
+    Only warn if all of the cached images are above the warning threshold, and only
+    fail if none of them are below the error threshold. The closest matching cached
+    image is returned along with the messages.
+    """
+    closest_image = cached_image_paths[0]
+    best_error: float | None = None
+    fail_msg: str | None = None
+
+    for path in cached_image_paths:
+        try:
+            error = _compare_images(test_image, path)
+        except RuntimeError as e:
+            if best_error is None and fail_msg is None:
+                # Only report this if no image can be compared successfully
+                fail_msg = repr(e)
+            continue
+
+        if best_error is None or error < best_error:
+            best_error, closest_image = error, path
+
+        if error <= allowed_warning:
+            # A clean match, no other image can improve on this outcome
+            break
+
+    if best_error is None:
+        return None, fail_msg, closest_image
+
+    fail_msg = _check_compare_fail(test_name, best_error, allowed_error)
+    warn_msg = _check_compare_warn(test_name, best_error, allowed_warning)
+
+    if (fail_msg or warn_msg) and len(cached_image_paths) > 1:
+        msg_closest = f"\nThis test has multiple cached images. The closest match was:\n\t{closest_image}"
+        if fail_msg:
+            fail_msg += msg_closest
+        else:
+            warn_msg = cast("str", warn_msg) + msg_closest
+
+    return warn_msg, fail_msg, closest_image
 
 
 def _check_compare_fail(test_name: str, error_: float, allowed_error: float) -> str | None:

--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -12,6 +12,7 @@ import sys
 import pytest
 import pyvista as pv
 
+from pytest_pyvista import doc_mode
 from pytest_pyvista.doc_mode import _DocVerifyImageCache
 from pytest_pyvista.doc_mode import _html_screenshots
 from pytest_pyvista.doc_mode import _vtksz_to_html_files
@@ -250,8 +251,15 @@ ALMOST_RED = [254, 0, 0]
     ("build_color", "return_code"), [(ALMOST_RED, pytest.ExitCode.OK), (ALMOST_BLUE, pytest.ExitCode.OK), ("green", pytest.ExitCode.TESTS_FAILED)]
 )
 @pytest.mark.parametrize("image_format", ["png", "jpg"])
-def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_code, nested_subdir, failed_image_dir, image_format) -> None:  # noqa: PLR0913
+def test_multiple_cache_images(  # noqa: PLR0913
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch, build_color, return_code, nested_subdir, failed_image_dir, image_format
+) -> None:
     """Test when cache is a subdir with multiple images."""
+    if build_color == ALMOST_BLUE:
+        # Lower the warning threshold so that the matching second image is not a
+        # clean match and a warning is emitted for it instead
+        monkeypatch.setattr(doc_mode, "DEFAULT_WARNING_THRESHOLD", -1.0)
+
     cache = "cache"
     images = "images"
     name = f"imcache.{image_format}"
@@ -275,17 +283,18 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
     if build_color == ALMOST_RED:
         # Comparison with first image succeeds without issue
         result.stdout.no_re_match_line(rf".*UserWarning: {partial_match}")
+        result.stdout.no_re_match_line(r".*This test has multiple cached images.*")
 
         # Test no images are saved
         assert not Path(failed).is_dir()
 
     elif build_color == ALMOST_BLUE:
-        # Comparison with first image fails
-        # Expect error was converted to a warning
+        # Comparison with first image errors, but the second image is the closest
+        # match and is only above the warning threshold
         result.stdout.re_match_lines(
             [
-                rf".*UserWarning: {partial_match}",
-                r".*This test has multiple cached images. It initially failed \(as above\) but passed when compared to:",
+                r".*UserWarning: imcache Exceeded image regression warning of -1\.0 with an image error of [0-9]+\.[0-9]+",
+                r".*This test has multiple cached images. The closest match was:",
                 f".*im2.{image_format}",
             ]
         )
@@ -305,7 +314,7 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
         result.stdout.re_match_lines(
             [
                 rf".*Failed: {partial_match}",
-                r".*This test has multiple cached images. It initially failed \(as above\) and failed again for all images in:",
+                r".*This test has multiple cached images. The closest match was:",
                 ".*" + re.escape(str(Path("cache/imcache"))),
             ]
         )
@@ -322,6 +331,39 @@ def test_multiple_cache_images(pytester: pytest.Pytester, build_color, return_co
         assert from_test.is_file() == failed_image_dir
         if failed_image_dir:
             assert file_has_changed(str(from_test), str(from_cache))
+
+
+@pytest.mark.parametrize("error_value", [500.0, 100000.0], ids=["initially_errors", "initially_warns"])
+def test_multiple_cache_images_clean_match(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch, error_value: float) -> None:
+    """
+    Test that a clean match with any cached image passes silently.
+
+    The first cached image is always compared first and does not match here. Whether
+    that mismatch initially exceeds the error threshold or only the warning threshold,
+    the second cached image is a clean match and so the test must pass without
+    emitting a warning.
+    """
+    monkeypatch.setattr(doc_mode, "DEFAULT_ERROR_THRESHOLD", error_value)
+
+    cache = "cache"
+    images = "images"
+    name = "imcache.png"
+    subdir = Path(name).stem
+    cache_parent = pytester.path / cache
+    make_cached_images(cache_parent, subdir, name="im1.png", color="red")
+    make_cached_images(cache_parent, subdir, name="im2.png", color="blue")
+    make_cached_images(pytester.path, images, name=name, color=ALMOST_BLUE)
+
+    failed = "failed"
+    args = ["--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache, "--failed_image_dir", failed]
+    result = pytester.runpytest(*args)
+
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.no_re_match_line(r".*imcache Exceeded image regression.*")
+    result.stdout.no_re_match_line(r".*This test has multiple cached images.*")
+
+    # Test no images are saved
+    assert not Path(failed).is_dir()
 
 
 @pytest.mark.parametrize("include_vtksz", [True, False])

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -988,10 +988,15 @@ def test_multiple_cache_images(  # noqa: PLR0913
     red_filename = make_cached_images(cache_parent, subdir, name=f"im1.{image_format}", color="red")
     blue_filename = make_cached_images(cache_parent, subdir, name=f"im2.{image_format}", color="blue")
 
+    # For the ALMOST_BLUE case, lower the warning threshold so that the matching
+    # second image is not a clean match and a warning is emitted for it instead
+    warning_value = -1.0 if build_color == ALMOST_BLUE else 200.0
+
     pyfile = f"""
         import pyvista as pv
         pv.OFF_SCREEN = True
         def test_imcache(verify_image_cache):
+            verify_image_cache.warning_value = {warning_value}
             sphere = pv.Sphere()
             plotter = pv.Plotter()
             plotter.add_mesh(sphere, color={build_color})
@@ -1012,17 +1017,18 @@ def test_multiple_cache_images(  # noqa: PLR0913
     if build_color == ALMOST_RED:
         # Comparison with first image succeeds without issue
         result.stdout.no_re_match_line(rf".*UserWarning: {partial_match}")
+        result.stdout.no_re_match_line(r".*This test has multiple cached images.*")
 
         # Test no images are saved
         assert not Path(failed).is_dir()
 
     elif build_color == ALMOST_BLUE:
-        # Comparison with first image fails
-        # Expect error was converted to a warning
+        # Comparison with first image errors, but the second image is the closest
+        # match and is only above the warning threshold
         result.stdout.re_match_lines(
             [
-                rf".*UserWarning: {partial_match}",
-                r".*This test has multiple cached images. It initially failed \(as above\) but passed when compared to:",
+                r".*UserWarning: imcache Exceeded image regression warning of -1\.0 with an image error of [0-9]+\.[0-9]+",
+                r".*This test has multiple cached images. The closest match was:",
                 f".*im2.{image_format}",
             ]
         )
@@ -1042,7 +1048,7 @@ def test_multiple_cache_images(  # noqa: PLR0913
         result.stdout.re_match_lines(
             [
                 rf".*RegressionError: {partial_match}",
-                r".*This test has multiple cached images. It initially failed \(as above\) and failed again for all images in:",
+                r".*This test has multiple cached images. The closest match was:",
                 f".*{re.escape(str(Path('cache/imcache')))}",
             ]
         )
@@ -1059,6 +1065,47 @@ def test_multiple_cache_images(  # noqa: PLR0913
         assert from_test.is_file() == failed_image_dir
         if failed_image_dir:
             assert file_has_changed(str(from_test), str(from_cache))
+
+
+@pytest.mark.parametrize("error_value", [500.0, 100000.0], ids=["initially_errors", "initially_warns"])
+def test_multiple_cache_images_clean_match(pytester: pytest.Pytester, error_value: float) -> None:
+    """
+    Test that a clean match with any cached image passes silently.
+
+    The first cached image is always compared first and does not match here. Whether
+    that mismatch initially exceeds the error threshold or only the warning threshold,
+    the second cached image is a clean match and so the test must pass without
+    emitting a warning.
+    """
+    cache = "cache"
+    name = "imcache.png"
+    subdir = Path(name).stem
+    cache_parent = pytester.path / cache
+    make_cached_images(cache_parent, subdir, name="im1.png", color="red")
+    make_cached_images(cache_parent, subdir, name="im2.png", color="blue")
+
+    pytester.makepyfile(
+        f"""
+        import pyvista as pv
+        pv.OFF_SCREEN = True
+        def test_imcache(verify_image_cache):
+            verify_image_cache.error_value = {error_value}
+            sphere = pv.Sphere()
+            plotter = pv.Plotter()
+            plotter.add_mesh(sphere, color={ALMOST_BLUE})
+            plotter.show()
+        """
+    )
+
+    failed = "failed"
+    result = pytester.runpytest("--image_cache_dir", cache, "--failed_image_dir", failed)
+
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.no_re_match_line(r".*imcache Exceeded image regression.*")
+    result.stdout.no_re_match_line(r".*This test has multiple cached images.*")
+
+    # Test no images are saved
+    assert not Path(failed).is_dir()
 
 
 @pytest.mark.parametrize("on_ci", [True, False], ids=["on_ci", "not_on_ci"])


### PR DESCRIPTION
Closes #286. Closes #303. Supersedes #295, which can be closed with this.

Implements the rule agreed in #303: *warn only if all of the images are above the
warning threshold, and error only if none of the images are under the error
threshold.*

### What

When a test has a directory of cached baselines, the comparison against the remaining
images was gated on the first comparison producing an error:

```python
if fail_msg and len(cached_image_paths) > 1:
```

Two consequences:

1. A mismatch landing between `warning_value` and `error_value` never consulted the
   other baselines at all — the warning was emitted without ever looking at them
   (#303).
2. An error that *was* rescued could only ever be demoted to a warning, even when the
   rescuing image was an exact match (#286).

This compares against every cached image and grades the test on the closest match. The
loop short circuits on the first image at or under `warning_value`, so a correctly
cached test still costs exactly one comparison — only a test that is already going to
warn or fail pays for the rest.

`doc_mode.test_images` carried a second copy of the same loop, so the whole comparison
now lives in `_test_compare_images` and both call sites share it. That also drops a
small inconsistency in doc mode, where the first comparison went through
`_compare_images` but the retries called `pv.compare_images(pv.read(...), ...)`
directly.

### Behaviour

| closest match | before | after |
|---|---|---|
| under `warning_value` | pass silently *(only if it was the first image)* | pass silently |
| between the thresholds | warning | warning |
| over `error_value` | fail | fail |

The grade now depends only on the *set* of cached images, not on which one happens to
sort first. `_get_file_paths` returns them sorted, so previously a cache whose ordering
didn't match the environment warned on every healthy run — the motivating case in #303
is a `+proj=eqc` baseline pair that differ from each other by 251.18, against the
default thresholds of 200/500.

Single-image caches are unaffected: the loop runs once and grades on that image, as
before.

One knock-on: `--reset_only_failed` now resets the closest-matching cached image rather
than always the first one in the directory, which seems like the more useful variant to
update. Single-image caches are unchanged.

### Messages

`--failed_image_dir` and the warning/error text now report the closest match rather
than the first image compared:

```
imcache Exceeded image regression error of 500.0 with an image error equal to: 806.7
This test has multiple cached images. The closest match was:
	cache/imcache/im2.png
```

replacing `It initially failed (as above) but passed when compared to:` /
`and failed again for all images in:`, neither of which describes what now happens.

The paragraph in `README.rst` describing the old first-then-the-rest algorithm has been
rewritten to match.

### Tests

Mirrored in `test_pyvista.py` and `test_doc_mode.py`:

* New `test_multiple_cache_images_clean_match`, parametrised over an initial mismatch
  that errors and one that only warns. Both must pass silently. All four
  parametrisations fail on `main`.
* `test_multiple_cache_images` keeps its structure and its `--failed_image_dir`
  coverage. Its `ALMOST_BLUE` case exercised the error-demoted-to-warning path by
  relying on the second cached image being an exact match — which now passes silently —
  so the warning threshold is lowered to `-1.0`, making that image the closest match
  but not a clean one, which is the warning case under the new rule. `ALMOST_RED`
  additionally asserts that a clean match against the first image says nothing at all.

Verified against the full suite: the set of non-passing tests is byte-identical to
`main`, plus the four new passes. (My machine has no `playwright` browsers installed,
so `check_playwright_config` was stubbed out identically in both runs; the `vtksz`
tests fail either way and are unaffected by this change.)

### On staleness

Per the discussion in #303 this doesn't try to detect stale cache entries.
`--disallow_unused_cache` is the natural home for that and can't do it today —
`cached_image_names` is built from a non-recursive `cache_path.glob(f"*.{image_format}")`
so variant subdirectories are never candidates, and `VISITED_CACHED_IMAGE_NAMES` records
the test's image name rather than the variant that matched. Happy to look at that
separately if it's wanted.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)