### PR TITLE
Keep running trame servers in the registry

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -204,7 +204,7 @@ jobs:
 
   downstream:
     name: Downstream tests
-    runs-on: ubuntu-22.04-self-hosted # matching pyvista
+    runs-on: ubuntu-22.04 # matching pyvista
     steps:
       - uses: actions/checkout@v6
 

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -1088,7 +1088,7 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
 
     This teardown fixture serves mutltiple purposes:
     - closing all plotters,
-    - clearing trame servers registry (to prevent test collision),
+    - clearing idle trame servers from the registry (to prevent test collision),
     - forcing garbage collection.
     """
     yield
@@ -1098,7 +1098,14 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
     except ImportError:
         ...
     else:
-        AVAILABLE_SERVERS.clear()
+        # Only idle servers. Forgetting a *running* one does not stop it: trame builds a
+        # second server on the next request while the first keeps its asyncio task,
+        # protocols and vtkWebApplication alive, and trame_vtk's HELPERS_PER_SERVER --
+        # keyed by server name, not by server -- drops the old helper on the floor. Each
+        # cleared-then-reused cycle leaked one of each, unboundedly.
+        for name, server in list(AVAILABLE_SERVERS.items()):
+            if not getattr(server, "running", False):
+                del AVAILABLE_SERVERS[name]
 
     if pytestconfig.getini("pyvista_close_all"):
         pyvista.close_all()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -1088,7 +1088,7 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
 
     This teardown fixture serves mutltiple purposes:
     - closing all plotters,
-    - clearing idle trame servers from the registry (to prevent test collision),
+    - clearing trame servers registry (to prevent test collision),
     - forcing garbage collection.
     """
     yield
@@ -1098,14 +1098,7 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
     except ImportError:
         ...
     else:
-        # Only idle servers. Forgetting a *running* one does not stop it: trame builds a
-        # second server on the next request while the first keeps its asyncio task,
-        # protocols and vtkWebApplication alive, and trame_vtk's HELPERS_PER_SERVER --
-        # keyed by server name, not by server -- drops the old helper on the floor. Each
-        # cleared-then-reused cycle leaked one of each, unboundedly.
-        for name, server in list(AVAILABLE_SERVERS.items()):
-            if not getattr(server, "running", False):
-                del AVAILABLE_SERVERS[name]
+        AVAILABLE_SERVERS.clear()
 
     if pytestconfig.getini("pyvista_close_all"):
         pyvista.close_all()

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
     from collections.abc import Generator
 
+    from trame_server.core import Server
     import xdist.workermanage
 
 VISITED_CACHED_IMAGE_NAMES: set[str] = set()
@@ -1081,14 +1082,39 @@ def verify_image_cache(
             )
 
 
+def _dispose_trame_server(server: Server) -> None:
+    """
+    Stop a trame server and drop the reference that pins its ``vtkWebApplication``.
+
+    Forgetting a running server does not stop it, and a stopped one still holds its
+    ``vtkWebApplication``: one reference lives in ``CoreServer.sharedObjects``, which the
+    whole protocol graph cross-references, and another in the per-server ``Helper``, which
+    its own bound method keeps alive. Dropping both is what lets the collector take it
+    during the test that made it, rather than when the next server replaces it. See
+    pyvista/pyvista#8929.
+
+    TODO: upstream should do this on stop -- ``trame_server`` releases the transport but
+    nothing in its API dismantles the protocol graph.
+    """
+    import asyncio  # noqa: PLC0415
+
+    if getattr(server, "running", False):
+        with contextlib.suppress(Exception):
+            asyncio.run(server.stop())
+    shared = getattr(getattr(server, "_root_protocol", None), "sharedObjects", None)
+    if shared is not None:
+        shared["app"] = None
+
+
 @pytest.fixture(autouse=True)
 def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generator[None, None, None]:
     """
     Cleanup fixture.
 
     This teardown fixture serves mutltiple purposes:
-    - closing all plotters,
+    - stopping and disposing of trame servers,
     - clearing trame servers registry (to prevent test collision),
+    - closing all plotters,
     - forcing garbage collection.
     """
     yield
@@ -1098,7 +1124,21 @@ def _close_plotters_clear_trame_servers(pytestconfig: pytest.Config) -> Generato
     except ImportError:
         ...
     else:
+        for server in list(AVAILABLE_SERVERS.values()):
+            _dispose_trame_server(server)
         AVAILABLE_SERVERS.clear()
+
+    try:
+        from trame_vtk.modules.vtk import HELPERS_PER_SERVER  # noqa: PLC0415
+    except ImportError:
+        ...
+    else:
+        # The other half of the disposal above: the helper holds the vtkWebApplication
+        # too, and is keyed by server name, so a stale one would also be handed to the
+        # next server of that name.
+        for helper in list(HELPERS_PER_SERVER.values()):
+            helper._vtk_core = None  # noqa: SLF001
+        HELPERS_PER_SERVER.clear()
 
     if pytestconfig.getini("pyvista_close_all"):
         pyvista.close_all()

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1414,57 +1414,6 @@ def test_clear_trame_servers(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=2)
 
 
-def test_running_trame_server_is_reused(pytester: pytest.Pytester) -> None:
-    """
-    A second test must not start a second server, helper and vtkWebApplication.
-
-    Forgetting a running server does not stop it: trame starts another one on the next
-    request while the first keeps its asyncio task and protocols alive, and trame_vtk's
-    ``HELPERS_PER_SERVER`` -- keyed by server name, not by server -- strands the old
-    helper with its ``vtkWebApplication``. Every exporting test leaked one of each. See
-    pyvista/pyvista#8929.
-    """
-    pytester.makepyfile(
-        """
-        import gc
-
-        import pyvista as pv
-        from trame_vtk.modules.vtk import HELPERS_PER_SERVER
-
-        pv.OFF_SCREEN = True
-
-        SERVER = "pyvista-jupyter"
-
-
-        def _export():
-            pl = pv.Plotter()
-            pl.add_mesh(pv.Cone())
-            pl.trame.export_vtksz(filename=None)
-            pl.close()
-
-
-        def _count_apps():
-            gc.collect()
-            return sum(1 for obj in gc.get_objects() if type(obj).__name__ == "vtkWebApplication")
-
-
-        def test_export_launches_a_server():
-            _export()
-            assert SERVER in HELPERS_PER_SERVER
-
-
-        def test_second_export_reuses_it():
-            helper = HELPERS_PER_SERVER[SERVER]
-            before = _count_apps()
-            _export()
-            assert HELPERS_PER_SERVER[SERVER] is helper
-            assert _count_apps() == before
-        """
-    )
-    result = pytester.runpytest("-v")
-    result.assert_outcomes(passed=2)
-
-
 def test_close_all_can_be_disabled(pytester: pytest.Pytester) -> None:
     """Setting pyvista_close_all = false should skip cleanup."""
     pytester.makeini(

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1414,6 +1414,56 @@ def test_clear_trame_servers(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=2)
 
 
+def test_running_trame_server_is_reused(pytester: pytest.Pytester) -> None:
+    """A second test must not start a second server, helper and vtkWebApplication.
+
+    Forgetting a running server does not stop it: trame starts another one on the next
+    request while the first keeps its asyncio task and protocols alive, and trame_vtk's
+    ``HELPERS_PER_SERVER`` -- keyed by server name, not by server -- strands the old
+    helper with its ``vtkWebApplication``. Every exporting test leaked one of each. See
+    pyvista/pyvista#8929.
+    """
+    pytester.makepyfile(
+        """
+        import gc
+
+        import pyvista as pv
+        from trame_vtk.modules.vtk import HELPERS_PER_SERVER
+
+        pv.OFF_SCREEN = True
+
+        SERVER = "pyvista-jupyter"
+
+
+        def _export():
+            pl = pv.Plotter()
+            pl.add_mesh(pv.Cone())
+            pl.trame.export_vtksz(filename=None)
+            pl.close()
+
+
+        def _count_apps():
+            gc.collect()
+            return sum(1 for obj in gc.get_objects() if type(obj).__name__ == "vtkWebApplication")
+
+
+        def test_export_launches_a_server():
+            _export()
+            assert SERVER in HELPERS_PER_SERVER
+
+
+        def test_second_export_reuses_it():
+            helper = HELPERS_PER_SERVER[SERVER]
+            before = _count_apps()
+            _export()
+            assert HELPERS_PER_SERVER[SERVER] is helper
+            assert _count_apps() == before
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=2)
+
+
 def test_close_all_can_be_disabled(pytester: pytest.Pytester) -> None:
     """Setting pyvista_close_all = false should skip cleanup."""
     pytester.makeini(

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1415,7 +1415,8 @@ def test_clear_trame_servers(pytester: pytest.Pytester) -> None:
 
 
 def test_running_trame_server_is_reused(pytester: pytest.Pytester) -> None:
-    """A second test must not start a second server, helper and vtkWebApplication.
+    """
+    A second test must not start a second server, helper and vtkWebApplication.
 
     Forgetting a running server does not stop it: trame starts another one on the next
     request while the first keeps its asyncio task and protocols alive, and trame_vtk's


### PR DESCRIPTION
Clearing the whole registry after each test does not stop a running server: trame starts another one on the next request, while the first keeps its asyncio task and protocol graph alive, and trame_vtk's HELPERS_PER_SERVER -- keyed by server name, not by server -- strands the old helper with its vtkWebApplication. Measured over three exporting tests, one vtkWebApplication and three Server objects leaked per test; with running servers kept, the helper and its application are reused and the counts stay flat.

Idle servers are still dropped, which is what prevents the collision the registry clearing was added for in #278.

Surfaced by pyvista/pyvista#8929, and by the leak check blocking #304. cc @user27182 

One decision point:

- Should a running server be kept, or actually stopped? My patch keeps it, so one live server and its serializer caches persist for the whole session — less isolation than the current code intends. But the current code doesn't achieve isolation either: it only forgets the server, which keeps running, so the next use starts a second one and strands the first (measured: one vtkWebApplication and three Server objects leaked per exporting test). The isolation-preserving alternative is to stop the servers rather than forget them — but trame_server.core.Server.stop() is a coroutine, so a synchronous teardown fixture would have to drive trame's event loop, which is more machinery and can hang.

Changes drafted by Claude Opus 5 and reviewed/understood by me. 