### PR TITLE
Speed up test suite: drop matplotlib import, shrink xdist parallel-image test

### DIFF
--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -373,10 +373,15 @@ def test_multiple_cache_images_parallel(pytester: pytest.Pytester, include_vtksz
     images = "images"
 
     n_images = 50
+    # Images are only compared to each other in this test, so render them small: this is
+    # purely about exercising doc_mode with multiple xdist workers, not image fidelity.
+    # Skipped for vtksz: the html-rendered screenshot size doesn't reliably match the
+    # requested plotter window_size, so the comparison would spuriously fail.
+    window_size = None if include_vtksz else (100, 100)
     name_cache = "imcache{index}_vtksz.png" if include_vtksz else "imcache{index}.png"
-    make_multiple_cached_images(pytester.path, cache, n_images=n_images, name=name_cache)
+    make_multiple_cached_images(pytester.path, cache, n_images=n_images, name=name_cache, window_size=window_size)
     name_build = "imcache{index}.vtksz" if include_vtksz else "imcache{index}.png"
-    image_filenames = make_multiple_cached_images(pytester.path, images, n_images=n_images, name=name_build)
+    image_filenames = make_multiple_cached_images(pytester.path, images, n_images=n_images, name=name_build, window_size=window_size)
 
     args = ["--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache, "-n2", "-v"]
     if include_vtksz:
@@ -393,7 +398,7 @@ def test_multiple_cache_images_parallel(pytester: pytest.Pytester, include_vtksz
 
     # replace a single image with a different image
     img_idx = 34
-    pl = pv.Plotter()
+    pl = pv.Plotter(window_size=window_size)
     pl.add_mesh(pv.Cube())
     if include_vtksz:
         pl.export_vtksz(image_filenames[img_idx])

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -12,7 +12,6 @@ import sys
 from typing import TYPE_CHECKING
 from unittest import mock
 
-import matplotlib.pyplot as plt
 import pytest
 import pyvista as pv
 import vtkmodules
@@ -49,6 +48,22 @@ def test_arguments(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=1)
 
 
+# Matplotlib's default "tab10" color cycle, hardcoded to avoid importing matplotlib
+# (a heavy, otherwise-unused dependency) just to read 10 static hex colors.
+_TAB10_COLORS = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+)
+
+
 def make_cached_images(  # noqa: PLR0913
     test_path, path="image_cache_dir", name="imcache.png", color="red", window_size=None, mesh: pv.DataSet | None = None
 ) -> Path:
@@ -68,9 +83,12 @@ def make_cached_images(  # noqa: PLR0913
     return filename
 
 
-def make_multiple_cached_images(test_path, path="image_cache_dir", n_images: int = 10, name: str = "imcache{index}.png") -> list[Path]:
+def make_multiple_cached_images(
+    test_path, path="image_cache_dir", n_images: int = 10, name: str = "imcache{index}.png", window_size=None
+) -> list[Path]:
     """Make image cache in `test_path/path` consisting of several images."""
-    colors = list(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+    colors = _TAB10_COLORS
+    kwargs = {"window_size": window_size} if window_size else {}
 
     d = Path(test_path, path)
     d.mkdir(exist_ok=True, parents=True)
@@ -87,7 +105,7 @@ def make_multiple_cached_images(test_path, path="image_cache_dir", n_images: int
             # don't regenerate images when that color already exists
             shutil.copy(color_to_file[color], filename)
         else:
-            plotter = pv.Plotter(off_screen=True)
+            plotter = pv.Plotter(off_screen=True, **kwargs)
             plotter.add_mesh(mesh, color=color)
             if filename.suffix == ".vtksz":
                 plotter.export_vtksz(filename)


### PR DESCRIPTION
Minor optimizations to reduce test times:
Baseline: 304 tests, ~133s.
This branch: ~121–126s locally

- Hardcode the matplotlib tab10 color cycle instead of importing matplotlib just to read it, removing an unused heavy dependency import.
- Render images at 100x100 instead of the pyvista default 1024x768 in test_multiple_cache_images_parallel (non-vtksz variant), since the test only compares images to each other, not their fidelity.