### PR TITLE
ci: drop vtk 9.2.2 runner, bump latest python to 3.14

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,13 +62,11 @@ jobs:
 
       matrix:
         include:
-          - python-version: "3.10"
-            vtk-version: "9.2.2"
           - python-version: "3.11"
             vtk-version: "latest"
           - python-version: "3.12"
             vtk-version: "latest"
-          - python-version: "3.13"
+          - python-version: "3.14"
             vtk-version: "latest"
     steps:
       - uses: actions/checkout@v7
@@ -104,11 +102,11 @@ jobs:
         run: xvfb-run tox run -e ${{env.TOX_FACTOR}}-cov-no_xdist
 
       - name: Combine coverage reports
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         run: tox run -e coverage
 
       - uses: codecov/codecov-action@v7
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         name: "Upload coverage to CodeCov"
         with:
           fail_ci_if_error: true
@@ -136,13 +134,11 @@ jobs:
 
       matrix:
         include:
-          - python-version: "3.10"
-            vtk-version: "9.2.2"
           - python-version: "3.11"
             vtk-version: "latest"
           - python-version: "3.12"
             vtk-version: "latest"
-          - python-version: "3.13"
+          - python-version: "3.14"
             vtk-version: "latest"
     steps:
       - uses: actions/checkout@v7
@@ -179,7 +175,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.12"
-          - python-version: "3.13"
+          - python-version: "3.14"
     steps:
       - uses: actions/checkout@v7
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
     tox-uv>=1
 
 env_list =
-    py3.{10-13}-vtk_latest
+    py3.{10-14}-vtk_latest
 
 [testenv]
 # ============= basic settings =============


### PR DESCRIPTION
## Summary
- Drop the `python 3.10` / `vtk 9.2.2` matrix entry from the Linux and Windows CI jobs.
- Bump the latest Python version from 3.13 to 3.14 across Linux, Windows, and macOS matrices.
- Extend tox's `env_list` range to include `py3.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)