### PR TITLE
Report an invalid image cache once per run instead of once per test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
-  "pytest>=6.2.0",
+  "pytest>=7.0.0",
 ]
 dynamic = ["description", "version"]
 license = "MIT"
@@ -47,7 +47,7 @@ tests = [
   "pytest-cov==7.1.0",
   "pytest-pyvista[vtksz]",
   "pytest-xdist==3.8.0",
-  "pytest>=6.2.0",
+  "pytest>=7.0.0",
   "pytest_mock<3.16",
   "pyvista[jupyter]>=0.37",
 ]

--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -33,7 +33,6 @@ from .pytest_pyvista import _is_master
 from .pytest_pyvista import _make_config_cache_dir
 from .pytest_pyvista import _paths_from_strings
 from .pytest_pyvista import _test_compare_images
-from .pytest_pyvista import _validate_image_cache_dir  # noqa: F401
 
 TEST_CASE_NAME = "_pytest_pyvista_test_case"
 TEST_CASE_NAME_VTKSZ_FILE_SIZE = "_pytest_pyvista_test_case_vtksz"
@@ -518,7 +517,6 @@ def max_vtksz_file_size(request: pytest.FixtureRequest) -> _VtkszFileSizeTestCas
     return test_case
 
 
-@pytest.mark.usefixtures("_validate_image_cache_dir")
 def test_images(_pytest_pyvista_test_case: _DocVerifyImageCache, doc_verify_image_cache: _DocVerifyImageCache) -> None:  # noqa: PT019, ARG001
     """Compare generated image with cached image."""
     test_case = _pytest_pyvista_test_case

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 from typing import TYPE_CHECKING
 from typing import Literal
+from typing import NoReturn
 from typing import cast
 from typing import get_args
 from typing import overload
@@ -50,6 +51,7 @@ SKIPPED_CACHED_IMAGE_NAMES: set[str] = set()
 PYVISTA_IMAGE_NAMES_CACHE_DIRNAME = "pyvista_image_names_dir"
 PYVISTA_GENERATED_IMAGE_CACHE_DIRNAME = "pyvista_generated_image_dir"
 PYVISTA_FAILED_IMAGE_CACHE_DIRNAME = "pyvista_failed_image_dir"
+INVALID_CACHE_CONFIG_ATTR = "_pytest_pyvista_invalid_cache_error"
 
 PARSER_GROUP_NAME = "pyvista"
 DEFAULT_ERROR_THRESHOLD: float = 500.0
@@ -892,14 +894,40 @@ class _ChainedCallbacks:
             f(plotter)
 
 
-@pytest.fixture(scope="session")
-def _validate_image_cache_dir(pytestconfig: pytest.Config) -> None:
+def _store_image_cache_dir_error(pytestconfig: pytest.Config) -> pytest.ExceptionInfo[InvalidCacheError] | None:
     """
-    Validate the contents of the image cache directory.
+    Validate the image cache directory and store any error on the config.
 
-    A session scope fixture is used since we only need to evaluate this once, and we want
-    the error raised during test setup.
+    The cache belongs to the run as a whole, not to any single test, so it is only
+    validated once. The error is stored instead of raised because pytest reports an
+    exception raised from ``pytest_configure`` as an internal error; it is reported
+    as a single collection error by :func:`pytest_collection` instead.
     """
+    excinfo = None
+    try:
+        _validate_image_cache_dir(pytestconfig)
+    except InvalidCacheError:
+        excinfo = cast("pytest.ExceptionInfo[InvalidCacheError]", pytest.ExceptionInfo.from_current())
+    setattr(pytestconfig, INVALID_CACHE_CONFIG_ATTR, excinfo)
+    return excinfo
+
+
+def _fail_collection(session: pytest.Session, excinfo: pytest.ExceptionInfo[InvalidCacheError]) -> NoReturn:
+    """
+    Report an invalid cache as a single collection error and stop the session.
+
+    The run is always interrupted, even with ``--continue-on-collection-errors``,
+    since no test can give a meaningful result with an invalid cache. Only the xdist
+    master reports the error; interrupting a worker is reported as a worker crash.
+    """
+    report = pytest.CollectReport(nodeid=session.nodeid, outcome="failed", longrepr=session.repr_failure(excinfo), result=[])
+    session.ihook.pytest_collectreport(report=report)
+    msg = "1 error during collection"
+    raise session.Interrupted(msg)
+
+
+def _validate_image_cache_dir(pytestconfig: pytest.Config) -> None:
+    """Validate the contents of the image cache directory configured for the session."""
     if pytestconfig.getoption("doc_mode"):
         from pytest_pyvista.doc_mode import _DocVerifyImageCache  # noqa: PLC0415
 
@@ -1015,6 +1043,10 @@ def pytest_configure(config: pytest.Config) -> None:
         _VtkszFileSizeTestCase.init_from_config(config)
         _DocVerifyImageCache.init_from_config(config)
 
+        # Validate the cache before the expensive preprocessing below
+        if _store_image_cache_dir_error(config):
+            return
+
         if is_master:
             # Clear any cached test files
             _make_config_cache_dir(config, PYVISTA_GENERATED_IMAGE_CACHE_DIRNAME, clean=True)
@@ -1038,6 +1070,8 @@ def pytest_configure(config: pytest.Config) -> None:
                 "vtksz_input_paths": _strings_from_paths(vtksz_input_paths),
                 "vtksz_test_image_paths": _strings_from_paths(vtksz_test_image_paths),
             }
+    else:
+        _store_image_cache_dir_error(config)
 
 
 try:
@@ -1057,7 +1091,6 @@ def verify_image_cache(
     request: pytest.FixtureRequest,
     pytestconfig: pytest.Config,
     monkeypatch: pytest.MonkeyPatch,
-    _validate_image_cache_dir: None,
 ) -> Generator[VerifyImageCache, None, None]:
     """Check cached images against test images for PyVista."""
     # Set CMD options in class attributes
@@ -1255,6 +1288,14 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
     if config.getoption("doc_mode"):
         return True
     return None
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection(session: pytest.Session) -> None:
+    """Report an invalid image cache as a single collection error before any test is collected."""
+    config = session.config
+    if _is_master(config) and (excinfo := getattr(config, INVALID_CACHE_CONFIG_ATTR, None)):
+        _fail_collection(session, excinfo)
 
 
 def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1348,14 +1348,13 @@ def test_validate_cache_image_format(*, pytester: pytest.Pytester, valid_format,
         )
 
     result = pytester.runpytest(*args)
-    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+    result.assert_outcomes(errors=1)
 
-    result.stdout.fnmatch_lines("E           pytest_pyvista.pytest_pyvista.InvalidCacheError: The image format required by")
-    result.stdout.fnmatch_lines(f"E           the image cache directory is {valid_format!r}, but {invalid_format!r} images exist in the cache.")
-    result.stdout.fnmatch_lines("E           Cache directory: *")
-    result.stdout.fnmatch_lines(
-        f"E           Invalid images: ['{re.escape(str(Path('imcache/imcache')))}.{invalid_format}', 'imcache.{invalid_format}']"
-    )
+    result.stdout.fnmatch_lines("E   pytest_pyvista.pytest_pyvista.InvalidCacheError: The image format required by")
+    result.stdout.fnmatch_lines(f"E   the image cache directory is {valid_format!r}, but {invalid_format!r} images exist in the cache.")
+    result.stdout.fnmatch_lines("E   Cache directory: *")
+    result.stdout.fnmatch_lines(f"E   Invalid images: ['{re.escape(str(Path('imcache/imcache')))}.{invalid_format}', 'imcache.{invalid_format}']")
 
 
 @pytest.mark.parametrize("ignore_image_cache", [True, False])
@@ -1379,8 +1378,8 @@ def test_validate_cache_unique_names_ignore_image_cache(*, pytester: pytest.Pyte
     if ignore_image_cache:
         result.assert_outcomes(passed=1)
     else:
-        assert result.ret == pytest.ExitCode.TESTS_FAILED
-        result.stdout.fnmatch_lines("E           pytest_pyvista.pytest_pyvista.InvalidCacheError: Non-unique image test names detected in the cache.")
+        assert result.ret == pytest.ExitCode.INTERRUPTED
+        result.stdout.fnmatch_lines("E   pytest_pyvista.pytest_pyvista.InvalidCacheError: Non-unique image test names detected in the cache.")
 
 
 @pytest.mark.parametrize("doc_mode", [True, False])
@@ -1405,12 +1404,37 @@ def test_validate_cache_unique_names(*, pytester: pytest.Pytester, doc_mode: boo
         )
 
     result = pytester.runpytest(*args)
-    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+    result.assert_outcomes(errors=1)
 
-    result.stdout.fnmatch_lines("E           pytest_pyvista.pytest_pyvista.InvalidCacheError: Non-unique image test names detected in the cache.")
-    result.stdout.fnmatch_lines("E           An image's name must not share the same name as a subdirectory. Either the image")
-    result.stdout.fnmatch_lines("E           or the subdirectory should be removed for the following test cases:")
-    result.stdout.fnmatch_lines(f"E           {{{test_name!r}}}")
+    result.stdout.fnmatch_lines("E   pytest_pyvista.pytest_pyvista.InvalidCacheError: Non-unique image test names detected in the cache.")
+    result.stdout.fnmatch_lines("E   An image's name must not share the same name as a subdirectory. Either the image")
+    result.stdout.fnmatch_lines("E   or the subdirectory should be removed for the following test cases:")
+    result.stdout.fnmatch_lines(f"E   {{{test_name!r}}}")
+
+
+def test_validate_cache_error_reported_once(pytester: pytest.Pytester) -> None:
+    """Test the cache is only validated once per run, and not once per test."""
+    test_name = "imcache"
+    name = f"{test_name}.png"
+    cache = "image_cache_dir"
+    make_cached_images(pytester.path, path=cache, name=name)
+    make_cached_images(pytester.path / cache, path=test_name, name=name)
+
+    num_tests = 3
+    pytester.makepyfile(
+        "\n".join(f"def test_{i}(verify_image_cache):\n    ...\n" for i in range(num_tests)),
+    )
+
+    result = pytester.runpytest()
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+
+    # The cache belongs to the run, so the error is reported once regardless of the number of tests
+    result.assert_outcomes(errors=1)
+    # Only match the error report itself; the short test summary repeats its first line
+    report_lines = [line for line in result.stdout.lines if line.startswith("E   ")]
+    assert sum("Non-unique image test names detected in the cache." in line for line in report_lines) == 1
+    assert sum(line == f"E   {{{test_name!r}}}" for line in report_lines) == 1
 
 
 def test_cli_args_classified() -> None:


### PR DESCRIPTION
`InvalidCacheError` came from a session-scoped fixture, and pytest re-raises a failed fixture's exception for every test requesting it — so one malformed cache errored every test in the suite.

Now validated once in `pytest_configure` and reported from `pytest_collection` as a single collection error that stops the run early. Message and exception type unchanged; exit code becomes 2 (`INTERRUPTED`). `pytest` floor bumped to 7.0.

🤖 [Claude Code](https://claude.com/claude-code)