### PR TITLE
Report every failed image in a test, not just the first

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,14 @@ If you need to use any flag inside the tests, you can modify the
         pl.show()
 
 
+A test may call ``pl.show()`` more than once, in which case the images are cached as
+``<test_name>``, ``<test_name>_1``, ``<test_name>_2`` and so on. Every one of these
+images is compared, even when an earlier one fails, and all of the failures are
+reported together as a single test failure. This way a test that renders several
+images writes all of them to ``--generated_image_dir`` and ``--failed_image_dir`` in
+one run, so every cached image can be reviewed, or refreshed, at once.
+
+
 Documentation image tests
 -------------------------
 Unlike the unit tests, which use the ``verify_image_cache`` fixture to evaluate test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 dependencies = [
+  # `pluggy.Result.force_exception`, used to report deferred regression errors
+  "pluggy>=1.1.0",
   "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
   "pytest>=6.2.0",
 ]

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -50,6 +50,7 @@ SKIPPED_CACHED_IMAGE_NAMES: set[str] = set()
 PYVISTA_IMAGE_NAMES_CACHE_DIRNAME = "pyvista_image_names_dir"
 PYVISTA_GENERATED_IMAGE_CACHE_DIRNAME = "pyvista_generated_image_dir"
 PYVISTA_FAILED_IMAGE_CACHE_DIRNAME = "pyvista_failed_image_dir"
+DEFERRED_ERRORS_ITEM_ATTR = "_pytest_pyvista_deferred_errors"
 
 PARSER_GROUP_NAME = "pyvista"
 DEFAULT_ERROR_THRESHOLD: float = 500.0
@@ -408,6 +409,14 @@ class VerifyImageCache:
         Directory to save failed images.  If not specified, no generated
         images are saved.
 
+    defer_errors : bool, default: False
+        Collect regression errors instead of raising them on the first failure.
+        The errors are stored in ``deferred_errors`` for the caller to report
+        once every image has been checked. This lets a test render all of its
+        images in a single run instead of stopping at the first mismatch. The
+        ``verify_image_cache`` fixture enables this and reports the collected
+        errors as a single test failure.
+
     Examples
     --------
     Create an image cache directory named image_cache and check a simple
@@ -444,6 +453,7 @@ class VerifyImageCache:
         var_warning_value: float = 1000.0,
         generated_image_dir: Path | None = None,
         failed_image_dir: Path | None = None,
+        defer_errors: bool = False,
     ) -> None:
         """Initialize VerifyImageCache."""
         self.test_name = test_name
@@ -472,6 +482,9 @@ class VerifyImageCache:
         self.skip = False
         self.n_calls = 0
 
+        self.defer_errors = defer_errors
+        self.deferred_errors: list[RegressionError | RegressionFileNotFoundError] = []
+
     @staticmethod
     def _is_skipped(*, skip: bool, windows_skip_image_cache: bool, macos_skip_image_cache: bool, ignore_image_cache: bool) -> bool:
         skip_windows = os.name == "nt" and windows_skip_image_cache
@@ -488,12 +501,6 @@ class VerifyImageCache:
             The Plotter object that is being closed.
 
         """
-
-        def remove_plotter_close_callback() -> None:
-            # Make sure this doesn't get called again if this plotter doesn't close properly
-            # This is typically needed if an error is raised by this function
-            plotter._before_close_callback = None  # noqa: SLF001
-
         test_name = f"{self.test_name}_{self.n_calls}" if self.n_calls > 0 else self.test_name
         self.n_calls += 1
 
@@ -537,9 +544,9 @@ class VerifyImageCache:
             if self.failed_image_dir is not None:
                 self._save_failed_test_images("error", plotter, image_name)
 
-            remove_plotter_close_callback()
             msg = f"{current_cached_image} does not exist in image cache"
-            raise RegressionFileNotFoundError(msg)
+            self._report_failure(RegressionFileNotFoundError(msg), plotter)
+            return
 
         if (self.add_missing_images and not current_cached_image.is_file()) or (self.reset_image_cache and not self.reset_only_failed):
             _screenshot(plotter, current_cached_image, max_image_size=VerifyImageCache.max_image_size)
@@ -572,14 +579,33 @@ class VerifyImageCache:
                 )
                 _screenshot(plotter, current_cached_image, max_image_size=VerifyImageCache.max_image_size)
             else:
-                remove_plotter_close_callback()
-                raise RegressionError(fail_msg)
+                self._report_failure(RegressionError(fail_msg), plotter)
+                # The image already failed, so don't also warn about it
+                return
 
         if warn_msg:
             parent_dir: Literal["errors_as_warning", "warning"] = "errors_as_warning" if image_dirname.is_dir() else "warning"
             if self.failed_image_dir is not None:
                 self._save_failed_test_images(parent_dir, plotter, image_name, cache_image_path=current_cached_image)
             warnings.warn(warn_msg, stacklevel=2)
+
+    def _report_failure(self, error: RegressionError | RegressionFileNotFoundError, plotter: Plotter) -> None:
+        """
+        Collect a regression error when deferring, otherwise raise it immediately.
+
+        Deferring lets the test keep rendering, and saving, the images that follow this
+        one so that a single run can refresh all of its cached images. The collected
+        errors are reported together once the test has finished. Raising instead aborts
+        the test at this image.
+        """
+        if self.defer_errors:
+            self.deferred_errors.append(error)
+            return
+
+        # Make sure this doesn't get called again if this plotter doesn't close properly
+        # This is typically needed if an error is raised by this function
+        plotter._before_close_callback = None  # noqa: SLF001
+        raise error
 
     def _save_generated_image(self, plotter: pyvista.Plotter, image_name: str, parent_dir: Path | None = None) -> None:
         parent = cast("Path", self.generated_image_dir) if parent_dir is None else parent_dir
@@ -866,6 +892,44 @@ def _get_option_from_config_or_ini(pytestconfig: pytest.Config, option: str, *, 
     return None
 
 
+def _collected_regression_error(errors: list[RegressionError | RegressionFileNotFoundError]) -> RegressionError | RegressionFileNotFoundError:
+    """
+    Combine the regression errors collected from a test into a single error.
+
+    A test that failed on a single image raises exactly the error it raised before
+    deferring was introduced. Several errors are joined into one numbered message so
+    that every image is reported at once, keeping the type when they all share one.
+    """
+    if len(errors) == 1:
+        return errors[0]
+
+    error_types = {type(error) for error in errors}
+    error_type = error_types.pop() if len(error_types) == 1 else RegressionError
+
+    header = f"{len(errors)} images failed image regression:"
+    msg = "\n\n".join([header, *(f"({i}) {error}" for i, error in enumerate(errors, start=1))])
+    return error_type(msg)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item) -> Generator:
+    """
+    Fail a test that collected regression errors while it was running.
+
+    The errors are reported here rather than from the fixture's teardown so that the
+    failure is attributed to the test call, exactly as an immediately raised error is.
+    A test that failed on its own is left alone; its images have still been saved.
+    """
+    __tracebackhide__ = True
+    outcome = yield
+    errors = getattr(item, DEFERRED_ERRORS_ITEM_ATTR, None)
+    if errors and outcome.excinfo is None:
+        try:
+            raise _collected_regression_error(errors)
+        except (RegressionError, RegressionFileNotFoundError) as error:
+            outcome.force_exception(error)
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call) -> Generator:  # noqa: ANN001, ARG001
     """Store test results for inspection."""
@@ -1079,7 +1143,11 @@ def verify_image_cache(
         cache_dir=cache_dir,
         generated_image_dir=gen_dir,
         failed_image_dir=failed_dir,
+        # Let the test render and save every one of its images, then report all of
+        # the failures together from `pytest_runtest_call`
+        defer_errors=True,
     )
+    setattr(request.node, DEFERRED_ERRORS_ITEM_ATTR, verify_image_cache.deferred_errors)
 
     # Render under the testing theme; `_TestingTheme` is absent on older pyvista.
     with contextlib.suppress(ImportError):

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
     from collections.abc import Generator
 
+    from pluggy import Result
     from trame_server.core import Server
     import xdist.workermanage
 
@@ -912,7 +913,7 @@ def _collected_regression_error(errors: list[RegressionError | RegressionFileNot
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item: pytest.Item) -> Generator:
+def pytest_runtest_call(item: pytest.Item) -> Generator[None, Result, None]:
     """
     Fail a test that collected regression errors while it was running.
 

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -255,6 +255,102 @@ def test_verify_image_cache_fail_regression(pytester: pytest.Pytester) -> None:
     result.stdout.fnmatch_lines("*Exceeded image regression error*")
     result.stdout.fnmatch_lines("*pytest_pyvista.pytest_pyvista.RegressionError:*")
     result.stdout.fnmatch_lines("*Exceeded image regression error of*")
+    # A single failure is reported on its own, not as a numbered list
+    result.stdout.no_fnmatch_line("*images failed image regression*")
+
+
+def test_verify_image_cache_fail_regression_multiple_images(pytester: pytest.Pytester) -> None:
+    """Test every image of a failing test is checked, saved and reported."""
+    image_names = ["imcache.png", "imcache_1.png", "imcache_2.png"]
+    for name in image_names:
+        make_cached_images(pytester.path, name=name)
+
+    pytester.makepyfile(
+        """
+       import pyvista as pv
+       pv.OFF_SCREEN = True
+       def test_imcache(verify_image_cache):
+           for color in ["blue", "green", "black"]:
+               plotter = pv.Plotter()
+               plotter.add_mesh(pv.Sphere(), color=color)
+               plotter.show()
+       """
+    )
+
+    result = pytester.runpytest("--generated_image_dir", "gen_dir", "--failed_image_dir", "failed_dir")
+
+    # The test fails once, in its call phase, with all three images named
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*pytest_pyvista.pytest_pyvista.RegressionError: 3 images failed image regression:*",
+            "*(1) imcache Exceeded image regression error of*",
+            "*(2) imcache_1 Exceeded image regression error of*",
+            "*(3) imcache_2 Exceeded image regression error of*",
+        ]
+    )
+
+    # Every image is rendered and saved, so a single run can refresh every baseline
+    assert sorted(path.name for path in (pytester.path / "gen_dir").iterdir()) == image_names
+    assert sorted(path.name for path in (pytester.path / "failed_dir" / "errors" / "from_test").iterdir()) == image_names
+
+
+def test_verify_image_cache_fail_regression_multiple_images_not_found(pytester: pytest.Pytester) -> None:
+    """Test missing cached images are collected the same way as failed comparisons."""
+    pytester.makepyfile(
+        """
+       import pyvista as pv
+       pv.OFF_SCREEN = True
+       def test_imcache(verify_image_cache):
+           for _ in range(3):
+               plotter = pv.Plotter()
+               plotter.add_mesh(pv.Sphere(), color="blue")
+               plotter.show()
+       """
+    )
+
+    result = pytester.runpytest("--generated_image_dir", "gen_dir")
+
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*pytest_pyvista.pytest_pyvista.RegressionFileNotFoundError: 3 images failed image regression:*",
+            "*(1) *imcache.png does not exist in image cache*",
+            "*(2) *imcache_1.png does not exist in image cache*",
+            "*(3) *imcache_2.png does not exist in image cache*",
+        ]
+    )
+    assert sorted(path.name for path in (pytester.path / "gen_dir").iterdir()) == ["imcache.png", "imcache_1.png", "imcache_2.png"]
+
+
+def test_verify_image_cache_fail_regression_mixed_errors(pytester: pytest.Pytester) -> None:
+    """Test a mix of failed comparisons and missing images is reported as a RegressionError."""
+    # Only the first image is cached, so the second one cannot be compared at all
+    make_cached_images(pytester.path)
+
+    pytester.makepyfile(
+        """
+       import pyvista as pv
+       pv.OFF_SCREEN = True
+       def test_imcache(verify_image_cache):
+           for _ in range(2):
+               plotter = pv.Plotter()
+               plotter.add_mesh(pv.Sphere(), color="blue")
+               plotter.show()
+       """
+    )
+
+    result = pytester.runpytest("--generated_image_dir", "gen_dir")
+
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*pytest_pyvista.pytest_pyvista.RegressionError: 2 images failed image regression:*",
+            "*(1) imcache Exceeded image regression error of*",
+            "*(2) *imcache_1.png does not exist in image cache*",
+        ]
+    )
+    assert sorted(path.name for path in (pytester.path / "gen_dir").iterdir()) == ["imcache.png", "imcache_1.png"]
 
 
 @pytest.mark.parametrize("use_generated_image_dir", [True, False])
@@ -586,11 +682,12 @@ def test_reset_image_cache(pytester: pytest.Pytester, allow_unused_generated, ma
     result.assert_outcomes(passed=1)
 
 
-def test_cleanup(pytester: pytest.Pytester) -> None:
-    """Test cleanup of the `verify_image_cache` fixture."""
+@pytest.mark.parametrize("defer_errors", [True, False])
+def test_cleanup(pytester: pytest.Pytester, defer_errors) -> None:
+    """Test cleanup of the `verify_image_cache` fixture, whether or not errors are deferred."""
     make_cached_images(pytester.path)
     pytester.makepyfile(
-        """
+        f"""
        import pytest
        import pyvista as pv
        pv.OFF_SCREEN = True
@@ -601,6 +698,7 @@ def test_cleanup(pytester: pytest.Pytester) -> None:
            assert pv.global_theme.before_close_callback is None
 
        def test_imcache(cleanup_tester, verify_image_cache):
+           verify_image_cache.defer_errors = {defer_errors}
            sphere = pv.Sphere()
            plotter = pv.Plotter()
            plotter.add_mesh(sphere, color="blue")
@@ -613,7 +711,10 @@ def test_cleanup(pytester: pytest.Pytester) -> None:
     )
 
     result = pytester.runpytest()
-    result.assert_outcomes(passed=1)
+    # Deferring reports the regression after the test body, so the `except` above no
+    # longer swallows it; raising immediately keeps failing inside `show` as before.
+    # The theme callback is restored either way, otherwise `cleanup_tester` errors.
+    result.assert_outcomes(**({"failed": 1} if defer_errors else {"passed": 1}))
 
 
 @pytest.mark.parametrize("add_missing_images", [True, False])
@@ -997,7 +1098,6 @@ def test_failed_dir_relative(pytester: pytest.Pytester) -> None:
         """
         import pyvista as pv
         import pytest
-        from pytest_pyvista.pytest_pyvista import RegressionError
 
         pv.OFF_SCREEN = True
         import contextlib
@@ -1007,7 +1107,9 @@ def test_failed_dir_relative(pytester: pytest.Pytester) -> None:
             sphere = pv.Sphere()
             plotter = pv.Plotter()
             plotter.add_mesh(sphere, color="blue")
-            with contextlib.chdir(tmp_path), contextlib.suppress(RegressionError):
+            # The regression is reported after the test body, so `show` does not raise
+            # here and the path below is asserted while the test is still running
+            with contextlib.chdir(tmp_path):
                 plotter.show()
 
             assert (pytestconfig.rootpath / "failed/errors/from_test/imcache.png").exists()
@@ -1015,7 +1117,9 @@ def test_failed_dir_relative(pytester: pytest.Pytester) -> None:
     )
     args = ["--image_cache_dir", new_dir, "--failed_image_dir", "failed"]
     result = pytester.runpytest(*args)
-    result.assert_outcomes(passed=1)
+    # Only the deferred image regression fails the test; the assertion above passed
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("*RegressionError: imcache Exceeded image regression error of*")
 
 
 def test_auto_close(pytester: pytest.Pytester) -> None:


### PR DESCRIPTION
`verify_image_cache` raised `RegressionError` on the first image that failed to match its baseline. The error propagated out of `Plotter.show`, so a test that shows more than once never rendered its later images, and they never reached `--generated_image_dir`. Refreshing an N-image test's baselines took N rounds of CI — see pyvista/pyvista#9017, where `test_hide_cells` renders three images and needed three runs.

Collect the errors instead: `__call__` appends each failure to `deferred_errors` when the new `defer_errors` flag is set, and a `pytest_runtest_call` wrapper forces them onto the test call as one failure. Images were already saved before each raise, so this is enough for the test to render and save the rest. A three-image test that mismatches on all three now saves and names all three in a single run.

A single failure re-raises the original error, so its type and message are unchanged, and `defer_errors` is off by default so `VerifyImageCache` used directly still fails on the first image. Missing baselines accumulate the same way, keeping `RegressionFileNotFoundError`.

221 passed locally, 0 failed; the 126 `test_doc_mode.py` errors are a missing local playwright install on an untouched path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
