### PR TITLE
Allow the documentation image thresholds to be configured

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,6 +343,16 @@ tests.
      This option is completely independent from the ``--include_vtksz`` option. File
      sizes may be tested without any additional installation.
 
+* ``--doc_error_value <VALUE>`` and ``--doc_warning_value <VALUE>`` set the image
+  comparison error above which a documentation image test fails or warns. They default
+  to ``500`` and ``200``, and the warning value may not exceed the error value.
+
+  .. note::
+
+     Documentation images are resized to ``max_image_size`` before they are compared,
+     which lowers the error a given difference produces. Set these values relative to
+     the size the images are actually compared at.
+
 Conditional skip markers
 ------------------------
 The plugin registers five reusable markers so downstream PyVista projects do not

--- a/pytest_pyvista/doc_mode.py
+++ b/pytest_pyvista/doc_mode.py
@@ -66,6 +66,8 @@ class _DocVerifyImageCache:
     image_format: _AllowedImageFormats
     max_image_size: int | None = None
     include_vtksz: bool
+    error_value: float = DEFAULT_ERROR_THRESHOLD
+    warning_value: float = DEFAULT_WARNING_THRESHOLD
     _verbose: bool = False
     _terminalreporter: pytest.TerminalReporter = None
 
@@ -102,6 +104,12 @@ class _DocVerifyImageCache:
         cls.generate_subdirs = bool(_get_option_from_config_or_ini(config, "generate_subdirs"))
 
         cls.include_vtksz = bool(_get_option_from_config_or_ini(config, "include_vtksz"))
+
+        cls.error_value = _threshold_from_config(config, "doc_error_value", DEFAULT_ERROR_THRESHOLD)
+        cls.warning_value = _threshold_from_config(config, "doc_warning_value", DEFAULT_WARNING_THRESHOLD)
+        if cls.warning_value > cls.error_value:
+            msg = f"'doc_warning_value' ({cls.warning_value}) cannot be greater than 'doc_error_value' ({cls.error_value})."
+            raise ValueError(msg)
 
         cls._verbose = config.option.verbose
         cls._terminalreporter = config.pluginmanager.get_plugin("terminalreporter")
@@ -237,6 +245,18 @@ def _preprocess_build_images(  # noqa: PLR0913
     input_paths = input_png + input_gif + input_jpg
     output_paths = _preprocess_input_paths(input_paths, relative_to=build_images_dir)
     return _get_output(input_paths, output_paths)
+
+
+def _threshold_from_config(config: pytest.Config, option: str, default: float) -> float:
+    """Fetch an image comparison threshold, falling back to its default."""
+    value = _get_option_from_config_or_ini(config, option)
+    if value is None or value == "":
+        return default
+    try:
+        return float(cast("str | int", value))
+    except ValueError:
+        msg = f"{option!r} must be a number. Got:\n{value}."
+        raise ValueError(msg) from None
 
 
 def _get_max_image_size() -> int:
@@ -546,8 +566,8 @@ def test_images(_pytest_pyvista_test_case: _DocVerifyImageCache, doc_verify_imag
         test_name=test_case.test_name,
         test_image=test_image_path,
         cached_image_paths=cached_image_paths,
-        allowed_error=DEFAULT_ERROR_THRESHOLD,
-        allowed_warning=DEFAULT_WARNING_THRESHOLD,
+        allowed_error=_DocVerifyImageCache.error_value,
+        allowed_warning=_DocVerifyImageCache.warning_value,
     )
 
     if fail_msg:

--- a/pytest_pyvista/pytest_pyvista.py
+++ b/pytest_pyvista/pytest_pyvista.py
@@ -365,6 +365,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: PLR0915
             help="Maximum size allowed for vtksz interactive plot files.",
         )
 
+        option = "doc_error_value"
+        help_ = f"Image comparison error above which a documentation image test fails (default: {DEFAULT_ERROR_THRESHOLD})."
+        _add_doc_cli_option(f"--{option}", action="store", default=None, help=help_)
+        parser.addini(option, default=None, help=help_)
+
+        option = "doc_warning_value"
+        help_ = f"Image comparison error above which a documentation image test warns (default: {DEFAULT_WARNING_THRESHOLD})."
+        _add_doc_cli_option(f"--{option}", action="store", default=None, help=help_)
+        parser.addini(option, default=None, help=help_)
+
     group = parser.getgroup(PARSER_GROUP_NAME)
     _add_common_cli_and_ini_options()
     _add_unit_test_cli_and_ini_options()

--- a/tests/test_doc_mode.py
+++ b/tests/test_doc_mode.py
@@ -671,6 +671,71 @@ def test_include_vtksz(pytester: pytest.Pytester, include_vtksz, max_image_size)
     assert expected_file.is_file()
 
 
+@pytest.mark.parametrize("cli", [True, False])
+def test_doc_mode_thresholds(pytester: pytest.Pytester, *, cli: bool) -> None:
+    """Test the error and warning thresholds may be customized."""
+    cache = "cache"
+    images = "images"
+    name = "imcache.png"
+    make_cached_images(pytester.path, cache, name=name, color="red")
+    make_cached_images(pytester.path, images, name=name, color="red", mesh=pv.Sphere(theta_resolution=12))
+
+    error = pv.compare_images(str(pytester.path / cache / name), str(pytester.path / images / name))
+    assert error > 0
+
+    def run(error_value: float, warning_value: float) -> pytest.RunResult:
+        args = ["--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache]
+        if cli:
+            args.extend(["--doc_error_value", str(error_value), "--doc_warning_value", str(warning_value)])
+        else:
+            pytester.makeini(
+                f"""
+                [pytest]
+                doc_error_value = {error_value}
+                doc_warning_value = {warning_value}
+                """
+            )
+        return pytester.runpytest(*args)
+
+    # Both thresholds above the error: a clean pass
+    result = run(error * 2, error * 2)
+    assert result.ret == pytest.ExitCode.OK
+
+    # Only the warning threshold below the error: a warning, not a failure
+    result = run(error * 2, error / 2)
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.fnmatch_lines([f"*Exceeded image regression warning of {error / 2}*"])
+
+    # Both thresholds below the error: a failure
+    result = run(error / 2, error / 2)
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    result.stdout.fnmatch_lines([f"*Exceeded image regression error of {error / 2}*"])
+
+
+def test_doc_mode_thresholds_invalid(pytester: pytest.Pytester) -> None:
+    """Test a warning threshold above the error threshold is rejected."""
+    cache = "cache"
+    images = "images"
+    make_cached_images(pytester.path, cache)
+    make_cached_images(pytester.path, images)
+
+    args = ["--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache, "--doc_error_value", "10", "--doc_warning_value", "20"]
+    result = pytester.runpytest(*args)
+    result.stdout.fnmatch_lines(["*ValueError: 'doc_warning_value' (20.0) cannot be greater than 'doc_error_value' (10.0)."])
+
+
+def test_doc_mode_thresholds_not_a_number(pytester: pytest.Pytester) -> None:
+    """Test a non-numeric threshold is rejected."""
+    cache = "cache"
+    images = "images"
+    make_cached_images(pytester.path, cache)
+    make_cached_images(pytester.path, images)
+
+    args = ["--doc_mode", "--doc_images_dir", images, "--image_cache_dir", cache, "--doc_error_value", "abc"]
+    result = pytester.runpytest(*args)
+    result.stdout.fnmatch_lines(["*ValueError: 'doc_error_value' must be a number. Got:", "*abc."])
+
+
 @pytest.mark.parametrize("max_size", [1, None, "custom"])
 def test_max_vtksz_file_size(pytester: pytest.Pytester, max_size: int | None) -> None:
     """Test --max_vtksz_file_size option."""

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1577,10 +1577,9 @@ def test_unit_test_args_invalid_in_doc_mode(pytester, arg) -> None:
 def test_doc_mode_args_invalid_in_unit_test_mode(pytester, arg) -> None:
     """Run pytest unit tests with forbidden args."""
     args = [arg]
-    if arg == "--max_vtksz_file_size":
-        args.append("0")
-    elif arg == "--doc_images_dir":
-        args.append("foo")
+    values = {"--max_vtksz_file_size": "0", "--doc_images_dir": "foo", "--doc_error_value": "500", "--doc_warning_value": "200"}
+    if (value := values.get(arg)) is not None:
+        args.append(value)
     result = pytester.runpytest(*args)
 
     result.stderr.fnmatch_lines([f"ERROR: argument {arg} can only be used with --doc_mode enabled"])


### PR DESCRIPTION
Doc mode compared every image against the hardcoded 500 and 200 thresholds, with no way to change them. `--doc_error_value` and `--doc_warning_value`, and the matching ini options, now set them; the defaults are unchanged, and a warning value above the error value is rejected.

This came out of pyvista/pyvista#9089, where a scalar bar title changed from `from_list` to `unnamed` and the test only warned. Doc images are thumbnailed to `max_image_size` before they are compared, which took that difference from an error of 1620 at full resolution down to 311. Downstream projects can now lower the threshold instead of storing larger baselines.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
